### PR TITLE
make sure things update properly

### DIFF
--- a/src/simularium/VisAgent.ts
+++ b/src/simularium/VisAgent.ts
@@ -123,6 +123,7 @@ export default class VisAgent {
 
     public resetMesh(): void {
         this.visType = VisTypes.ID_VIS_TYPE_DEFAULT;
+        this.typeId = -1;
         this.mesh = new Mesh(VisAgent.sphereGeometry, this.baseMaterial);
         this.mesh.userData = { index: this.agentIndex };
         this.highlighted = false;

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -367,6 +367,8 @@ class VisGeometry {
                 );
             }
         }
+
+        this.updateScene(this.currentSceneAgents);
     }
 
     private resetAgentGeometry(visAgent, meshGeom): void {
@@ -398,6 +400,8 @@ class VisGeometry {
                 this.resetAgentPDB(visAgent, pdb);
             }
         }
+
+        this.updateScene(this.currentSceneAgents);
     }
 
     private resetAgentPDB(visAgent, pdb): void {


### PR DESCRIPTION
If you load the viewer example, then switch render mode, and then load a different trajectory, a variety of bugs were occurring.   New Agents could be redrawn with the wrong color and sometimes centered at the origin.   This is related to geometry for the agents potentially arriving after the first batch of positions.

The fix is a slightly heavy-handed call to run through the update loop again after each new geometry arrives.
I also had to reset the type id of the agents when clearing out their old geometry.