### PR TITLE
Feature/cancel downloads safely

### DIFF
--- a/src/simularium/PDBModel.ts
+++ b/src/simularium/PDBModel.ts
@@ -8,6 +8,7 @@ import KMeansWorkerModule from "./worker/KMeansWorker";
 import { KMeansWorkerType } from "./worker/KMeansWorker";
 
 import TaskQueue from "./worker/TaskQueue";
+import { REASON_CANCELLED } from "./worker/TaskQueue";
 
 interface PDBAtom {
     serial?: number;
@@ -94,7 +95,7 @@ class PDBModel {
             })
             .then(data => {
                 if (this.cancelled) {
-                    return Promise.reject("Cancelled");
+                    return Promise.reject(REASON_CANCELLED);
                 }
                 // note pdb atom coordinates are in angstroms
                 // 1 nm is 10 angstroms

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -6,6 +6,7 @@ import VisAgent from "./VisAgent";
 import VisTypes from "./VisTypes";
 import PDBModel from "./PDBModel";
 import TaskQueue from "./worker/TaskQueue";
+import { REASON_CANCELLED } from "./worker/TaskQueue";
 
 import {
     Box3,
@@ -532,7 +533,7 @@ class VisGeometry {
             },
             reason => {
                 this.pdbRegistry.delete(pdbName);
-                if (reason !== "Cancelled") {
+                if (reason !== REASON_CANCELLED) {
                     console.error(reason);
                     this.logger.debug("Failed to load pdb: ", pdbName);
                 }

--- a/src/simularium/worker/TaskQueue.ts
+++ b/src/simularium/worker/TaskQueue.ts
@@ -9,6 +9,8 @@ interface QueueItem<T> {
 
 const MAX_ACTIVE_WORKERS = 4;
 
+export const REASON_CANCELLED = "Cancelled";
+
 // class is exported mainly for testing convenience.
 // a "global" instance is also provided as the default export below.
 export class TaskQueue {
@@ -42,7 +44,7 @@ export class TaskQueue {
         while (this.queue.length > 0) {
             const item = this.queue.pop();
             if (item) {
-                item.reject("Cancelled");
+                item.reject(REASON_CANCELLED);
             }
         }
     }

--- a/src/test/TaskQueue.test.ts
+++ b/src/test/TaskQueue.test.ts
@@ -1,6 +1,6 @@
 import "regenerator-runtime/runtime";
 
-import { TaskQueue } from "../simularium/worker/TaskQueue";
+import { TaskQueue, REASON_CANCELLED } from "../simularium/worker/TaskQueue";
 
 const delay = t => {
     const resultPromise = new Promise(resolve => {
@@ -167,10 +167,10 @@ describe("TaskQueue module", () => {
             expect(value).toBe(1003);
         });
         p4.then(null, error => {
-            expect(error).toBe("Cancelled");
+            expect(error).toBe(REASON_CANCELLED);
         });
         p5.then(null, error => {
-            expect(error).toBe("Cancelled");
+            expect(error).toBe(REASON_CANCELLED);
         });
     });
     test("it can queue new tasks after cancelling", async () => {
@@ -207,10 +207,10 @@ describe("TaskQueue module", () => {
             expect(value).toBe(1003);
         });
         p4.then(null, error => {
-            expect(error).toBe("Cancelled");
+            expect(error).toBe(REASON_CANCELLED);
         });
         p5.then(null, error => {
-            expect(error).toBe("Cancelled");
+            expect(error).toBe(REASON_CANCELLED);
         });
         p6.then(value => {
             expect(value).toBe(1006);


### PR DESCRIPTION
When we load geometry, it happens asynchronously.  A trajectory can receive its geometry well after its first agent data has arrived.   On top of that, after pdb files arrive, we fire off worker processing to generate level of detail models.

When a new trajectory geometry file is being loaded, we should cancel any pending async geometry downloads and any async pdb model processing that is occurring.   This is implemented here by keeping a "cancel" flag with pdb and 3d obj requests.  When the cancelled requests resolve(or reject), I intercept them and prevent them from updating the current scene.
