### PR TITLE
reversed call to reset camera when unfollow obj

### DIFF
--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -439,7 +439,6 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
             this.visGeometry.addPathForAgentIndex(intersectedObject);
         } else {
             if (oldFollowObject !== NO_AGENT) {
-                this.resetCamera();
                 this.visGeometry.removePathForAgentIndex(oldFollowObject);
             }
             if (this.hit) {


### PR DESCRIPTION
**Pull request recommendations:**
This removes the call to resetCamera when you unfollow the object. Another piece of work would be to recenter the camera pivot to the center of the scene. 
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
