### PR TITLE
remove pdb coordinate fixup hack

### DIFF
--- a/src/simularium/PDBModel.ts
+++ b/src/simularium/PDBModel.ts
@@ -101,7 +101,7 @@ class PDBModel {
     public download(url: string): Promise<void> {
         const pdbRequest = new Request(url);
         return fetch(pdbRequest)
-            .then(response => {
+            .then((response) => {
                 if (!response.ok) {
                     throw new Error(
                         `Error fetching ${this.filePath} from ${url}`
@@ -109,7 +109,7 @@ class PDBModel {
                 }
                 return response.text();
             })
-            .then(data => {
+            .then((data) => {
                 if (this.cancelled) {
                     return Promise.reject(REASON_CANCELLED);
                 }
@@ -159,7 +159,7 @@ class PDBModel {
             return;
         }
         // PDB Angstroms to Simularium nanometers
-        const PDB_COORDINATE_SCALE = new Vector3(-0.1, 0.1, -0.1);
+        const PDB_COORDINATE_SCALE = new Vector3(0.1, 0.1, 0.1);
 
         for (let i = 0; i < this.pdb.atoms.length; ++i) {
             this.pdb.atoms[i].x *= PDB_COORDINATE_SCALE.x;


### PR DESCRIPTION
Stop flipping coordinates when loading PDB files.
@blairlyons Are you willing to fix up the pdbs we have on S3 before release to do this coordinate change?

We don't need to merge this PR before we're ready to update that data, but my feeling is we should release the first release being able to read PDBs without transforming their coordinates.
