### PR TITLE
Bugfix/fiber positions

### DIFF
--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1523,13 +1523,10 @@ class VisGeometry {
         }
 
         // set all runtime meshes back to spheres.
-        const nMeshes = this.visAgents.length;
-        for (let i = 0; i < MAX_MESHES && i < nMeshes; i += 1) {
-            const visAgent = this.visAgents[i];
-            if (visAgent.active) {
-                visAgent.resetMesh();
-                visAgent.resetPDB();
-            }
+        for (const visAgentKey in this.visAgentInstances) {
+            const visAgent = this.visAgentInstances[visAgentKey];
+            visAgent.resetMesh();
+            visAgent.resetPDB();
         }
     }
 


### PR DESCRIPTION
Fiber positions were not updating consistently on load.  This fixes it by forcing a position update just like non-fibers do.  The problem was that a former non-fiber agent mesh was being re-used as a fiber and it still had its old position stored.
