### PR TITLE
handle vistype change for agents that were fiber in the last frame

### DIFF
--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1093,6 +1093,7 @@ class VisGeometry {
                         this.getColorForTypeId(typeId),
                         this.getColorIndexForTypeId(typeId)
                     );
+                    visAgent.visType = visType;
                 }
 
                 const runtimeMesh = visAgent.mesh;


### PR DESCRIPTION
Currently agent instances in the viewer implementation can change from fiber to non-fiber and back (regardless of what the actual simulation is doing).  The case where an agent was fiber in one frame and non-fiber in the next frame was not being handled.
This code change makes sure that non fiber geometry is set up correctly when the agent instance thought it was previously a fiber.