### PR TITLE
Fix/agent instance map

### DIFF
--- a/src/simularium/VisAgent.ts
+++ b/src/simularium/VisAgent.ts
@@ -347,6 +347,7 @@ export default class VisAgent {
     public hideAndDeactivate(): void {
         this.hide();
         this.active = false;
+        this.id = NO_AGENT;
     }
 
     public hasDrawablePDB(): boolean {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -850,8 +850,6 @@ class VisGeometry {
     public resetMapping(): void {
         this.resetAllGeometry();
 
-        this.visAgentInstances.clear();
-
         this.visGeomMap.clear();
         this.meshRegistry.clear();
         this.pdbRegistry.clear();
@@ -1486,6 +1484,13 @@ class VisGeometry {
 
     public clear(): void {
         this.hideUnusedAgents(0);
+    }
+
+    public clearForNewTrajectory(): void {
+        this.resetMapping();
+        // remove current scene agents.
+        this.visAgentInstances.clear();
+        this.currentSceneAgents = [];
     }
 
     private cancelAllAsyncProcessing(): void {

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -46,7 +46,7 @@ interface Click {
 }
 
 interface ViewportState {
-    lastClick: Click
+    lastClick: Click;
 }
 
 interface TimeData {
@@ -440,7 +440,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
         const totalElapsedTime = now - this.startTime;
         if (elapsedTime > timePerFrame) {
             if (simulariumController.hasChangedFile) {
-                this.visGeometry.resetMapping();
+                this.visGeometry.clearForNewTrajectory();
                 // skip fetch if local file
                 const p = simulariumController.isLocalFile
                     ? Promise.resolve()


### PR DESCRIPTION
This change fixes some issues with loading new trajectories over existing ones.  There were two main problems:
1. The map of instance ids to agents was using square brackets instead of set and get.
2. The "currentSceneAgents" was not being cleared out -- so, scene updates could be triggered by the show/hide react state being reset before the new scene data arrived, which would keep repopulating the 3d scene with the previous agents.

I force the viewer to clear out the currentSceneAgents as soon as it knows a new trajectory has arrived.

Fixes AGENTVIZ-984 and AGENTVIZ-985