### PR TITLE
follow point on the middle of fiber

### DIFF
--- a/src/simularium/VisAgent.ts
+++ b/src/simularium/VisAgent.ts
@@ -1,6 +1,7 @@
 import {
     CatmullRomCurve3,
     Color,
+    Curve,
     Group,
     LineCurve3,
     Material,
@@ -79,6 +80,7 @@ export default class VisAgent {
     }
 
     public mesh: Object3D;
+    public fiberCurve?: Curve<Vector3>;
     // TODO can this default to a trivial single-atom pdb model?
     public pdbModel?: PDBModel;
     public pdbObjects: Object3D[];
@@ -120,6 +122,8 @@ export default class VisAgent {
         this.mesh = new Mesh(VisAgent.sphereGeometry, this.baseMaterial);
         this.mesh.userData = { id: this.id };
         this.mesh.visible = false;
+
+        this.fiberCurve = undefined;
 
         this.pdbModel = undefined;
         this.pdbObjects = [];
@@ -390,9 +394,9 @@ export default class VisAgent {
         }
 
         // set up new fiber as curved tube
-        const fibercurve = new CatmullRomCurve3(curvePoints);
+        this.fiberCurve = new CatmullRomCurve3(curvePoints);
         const fibergeometry = new TubeBufferGeometry(
-            fibercurve,
+            this.fiberCurve,
             (4 * numSubPoints) / 3,
             collisionRadius * scale * 0.5,
             8,
@@ -446,5 +450,13 @@ export default class VisAgent {
         // downstream code will switch this flag
         fiberGroup.visible = false;
         return fiberGroup;
+    }
+
+    public getFollowPosition(): Vector3 {
+        if (this.visType === VisTypes.ID_VIS_TYPE_FIBER && this.fiberCurve) {
+            return this.fiberCurve.getPoint(0.5);
+        } else {
+            return new Vector3().copy(this.mesh.position);
+        }
     }
 }

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1205,14 +1205,13 @@ class VisGeometry {
             const distance = direction.length();
             direction.normalize();
 
-            const newTarget = new Vector3();
             const followedObject = this.visAgentInstances.get(
                 this.followObjectId
             );
             if (!followedObject) {
                 return;
             }
-            newTarget.copy(followedObject.mesh.position);
+            const newTarget = followedObject.getFollowPosition();
 
             // update controls target for orbiting
             if (lerpTarget) {
@@ -1224,7 +1223,7 @@ class VisGeometry {
             // update new camera position
             const newPosition = new Vector3();
             newPosition.subVectors(
-                followedObject.mesh.position,
+                newTarget,
                 direction.multiplyScalar(-distance)
             );
             if (lerpPosition) {


### PR DESCRIPTION
This is the code change to make sure that fibers are followed more accurately.

The only thing interesting here is that we are completely throwing away the previous curve and re-creating the whole 3d fiber on each frame.  And now I am storing the CatmullRomCurve representation with each VisAgent.   This is incredibly fast/convenient for programmers to implement, and probably very inefficient at run time.  I don't have a great idea for optimizing curve updates beyond this.

