### PR TITLE
Fix/follow agent 0

### DIFF
--- a/src/simularium/rendering/GBufferPass.ts
+++ b/src/simularium/rendering/GBufferPass.ts
@@ -106,7 +106,7 @@ class GBufferPass {
         // 1. fill colorbuffer
 
         // clear color:
-        // x:0 agent type id
+        // x:0 agent type id (0 so that type ids can be positive or negative integers)
         // y:-1 agent instance id (-1 so that 0 remains a distinct instance id from the background)
         // z:0 view space depth
         // alpha == -1 is a marker to discard pixels later, will be filled with frag depth


### PR DESCRIPTION
When an agent has instance id = 0, the contour render pass was unable to distinguish it from background, for the purpose of drawing the "follow" outline.
The result was that you could click the object and the camera would follow it but it wouldn't be outlined.

The fix is to initialize the buffer that contains instance ids to a negative value rather than 0.

Implicit in all this is that per-frame instance ids are not allowed to be negative (Same goes for type ids, for that matter).