### PR TITLE
check for changes before doing expensive operation

### DIFF
--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -290,14 +290,28 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
         } = this.props;
 
         if (selectionStateInfo) {
-            const highlightedIds = this.selectionInterface.getHighlightedIds(
-                selectionStateInfo
-            );
-            const hiddenIds = this.selectionInterface.getHiddenIds(
-                selectionStateInfo
-            );
-            this.visGeometry.setHighlightByIds(highlightedIds);
-            this.visGeometry.setVisibleByIds(hiddenIds);
+            if (
+                !isEqual(
+                    selectionStateInfo.highlightedAgents,
+                    prevProps.selectionStateInfo.highlightedAgents
+                )
+            ) {
+                const highlightedIds = this.selectionInterface.getHighlightedIds(
+                    selectionStateInfo
+                );
+                this.visGeometry.setHighlightByIds(highlightedIds);
+            }
+            if (
+                !isEqual(
+                    selectionStateInfo.hiddenAgents,
+                    prevProps.selectionStateInfo.hiddenAgents
+                )
+            ) {
+                const hiddenIds = this.selectionInterface.getHiddenIds(
+                    selectionStateInfo
+                );
+                this.visGeometry.setVisibleByIds(hiddenIds);
+            }
         }
 
         // note that if the system does not support the molecular render style, then


### PR DESCRIPTION
During playback, react state is being set on every time update.  On state changes we need to avoid expensive operations and setHighlightByIds and setVisibleByIds can potentially do operations that are not suited for realtime.
