### PR TITLE
Fix/path drawing order

### DIFF
--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1610,7 +1610,6 @@ class VisGeometry {
         dz: number
     ): void {
         if (x === dx && y === dy && z === dz) {
-            console.log("skipping this point");
             return;
         }
         // Check for periodic boundary condition:


### PR DESCRIPTION
Introducing unique agent ids (and allowing those ids to be in a different order in each frame) left a bug in the path drawing code.
Path drawing was failing when followed instance did not occur in the same position in the trajectory data each frame.

This change actually looks up the instance Id to find the previous position to correctly draw the previous segment.
This is a major improvement but I am not yet 100% sure this fixes every case. 

There is also some minor code cleanup - removed some type casts and renamed a variable.