### PR TITLE
Fix "hidden agents reappear on play"

### DIFF
--- a/src/simularium/VisAgent.ts
+++ b/src/simularium/VisAgent.ts
@@ -180,8 +180,10 @@ export default class VisAgent {
     }
 
     public setHighlighted(highlighted: boolean): void {
-        this.highlighted = highlighted;
-        this.assignMaterial();
+        if (highlighted !== this.highlighted) {
+            this.highlighted = highlighted;
+            this.assignMaterial();
+        }
     }
 
     private assignMaterial(): void {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -451,33 +451,12 @@ class VisGeometry {
 
     public setVisibleByIds(hiddenIds: number[]): void {
         this.hiddenIds = hiddenIds;
-
-        // go over all objects and update material
-        const nMeshes = this.visAgents.length;
-        for (let i = 0; i < MAX_MESHES && i < nMeshes; i += 1) {
-            const visAgent = this.visAgents[i];
-            if (visAgent.active) {
-                const isHidden = this.hiddenIds.includes(visAgent.typeId);
-                visAgent.setHidden(isHidden);
-            }
-        }
         this.updateScene(this.currentSceneAgents);
     }
 
     public setHighlightByIds(ids: number[]): void {
         this.highlightedIds = ids;
-
-        // go over all objects and update material
-        const nMeshes = this.visAgents.length;
-        for (let i = 0; i < MAX_MESHES && i < nMeshes; i += 1) {
-            const visAgent = this.visAgents[i];
-            if (visAgent.active) {
-                const isHighlighted = this.highlightedIds.includes(
-                    visAgent.typeId
-                );
-                visAgent.setHighlighted(isHighlighted);
-            }
-        }
+        this.updateScene(this.currentSceneAgents);
     }
 
     public dehighlight(): void {
@@ -1243,6 +1222,10 @@ class VisGeometry {
 
             visAgent.typeId = typeId;
             visAgent.active = true;
+
+            const wasHidden = visAgent.hidden;
+            const isHidden = this.hiddenIds.includes(visAgent.typeId);
+            visAgent.setHidden(isHidden);
             if (visAgent.hidden) {
                 visAgent.hide();
                 return;
@@ -1251,7 +1234,11 @@ class VisGeometry {
             // if not fiber...
             if (visType === VisTypes.ID_VIS_TYPE_DEFAULT) {
                 // did the agent type change since the last sim time?
-                if (typeId !== lastTypeId || visType !== visAgent.visType) {
+                if (
+                    wasHidden ||
+                    typeId !== lastTypeId ||
+                    visType !== visAgent.visType
+                ) {
                     const meshGeom = this.getGeomFromId(typeId);
                     visAgent.visType = visType;
                     if (meshGeom) {
@@ -1357,7 +1344,7 @@ class VisGeometry {
                     }
                 }
                 // did the agent type change since the last sim time?
-                if (typeId !== lastTypeId) {
+                if (wasHidden || typeId !== lastTypeId) {
                     visAgent.mesh.userData = { id: visAgent.id };
                     // for fibers we currently only check the color
                     visAgent.setColor(
@@ -1405,6 +1392,8 @@ class VisGeometry {
                     );
                 }
             }
+            const isHighlighted = this.highlightedIds.includes(visAgent.typeId);
+            visAgent.setHighlighted(isHighlighted);
         });
 
         this.hideUnusedAgents(agents.length);


### PR DESCRIPTION
The bug was: when you hide an agent type and then resume playing, it is possible for other agents of that type to be added in later frames.  Those agents were not being hidden properly.

The fix here is to process visibility (and highlighting) updates in every updateScene call, so that all agents can be accounted for at later times.
It's a little more processing and we can profile later, but I am sure its cost is still dwarfed by much of the other update logic.
