### PR TITLE
make sure any resize calls don't use zero height or width

### DIFF
--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -704,6 +704,9 @@ class VisGeometry {
     }
 
     public resize(width: number, height: number): void {
+        // at least 2x2 in size when resizing, to prevent bad buffer sizes
+        width = Math.max(width, 2);
+        height = Math.max(height, 2);
         this.camera.aspect = width / height;
         this.camera.updateProjectionMatrix();
         this.renderer.setSize(width, height);
@@ -715,15 +718,10 @@ class VisGeometry {
             return;
         }
 
-        const height = parent.scrollHeight;
-        const width = parent.scrollWidth;
         parent.appendChild(this.renderer.domElement);
         this.setUpControls(this.renderer.domElement);
-        this.camera.aspect = width / height;
-        this.camera.updateProjectionMatrix();
-        this.renderer.setSize(width, height);
 
-        this.moleculeRenderer.resize(width, height);
+        this.resize(parent.scrollWidth, parent.scrollHeight);
 
         this.renderer.setClearColor(this.backgroundColor, 1.0);
         this.renderer.clear();


### PR DESCRIPTION
In simularium-website, the way the viewer component is embedded (via React) can result in its receiving a dom element that starts with zero height.  The resulting WebGL sizing code can result in errors that look like: 

[.WebGL-0x7fce6e855600]GL ERROR :GL_INVALID_FRAMEBUFFER_OPERATION : glClear: framebuffer incomplete
49[.WebGL-0x7fce6e855600]GL ERROR :GL_INVALID_FRAMEBUFFER_OPERATION : glDrawElements: framebuffer incomplete
7[.WebGL-0x7fce6e855600]RENDER WARNING: texture bound to texture unit 0 is not renderable. It might be non-power-of-2 or have incompatible texture filtering (maybe)?
7[.WebGL-0x7fce6e855600]RENDER WARNING: texture bound to texture unit 1 is not renderable. It might be non-power-of-2 or have incompatible texture filtering (maybe)?

The fix here is to never allow a resize with a zero sized dimension.  I somewhat arbitrarily assigned a minimum value of 2x2 pixels.