### PR TITLE
Fix/network loading issue

### DIFF
--- a/src/simularium/NetConnection.ts
+++ b/src/simularium/NetConnection.ts
@@ -224,7 +224,7 @@ export class NetConnection {
                     return await handleReturn();
                 } else if (connectionTries <= MAX_CONNECTION_TRIES) {
                     connectionTries++;
-                    return startPromise.then(handleReturn);
+                    return this.connectToUriAsync(address).then(handleReturn);
                 } else {
                     reject(
                         new Error(


### PR DESCRIPTION
This adds an additional second to the wait time for the socket connection and attempts one additional connection before erroring out. 

The max wait is 4 secs. If that seems too long I'm open to suggestions, here are two ideas I had: 
1. change the timeout function to half a second and do 3 tries, might increase the return speed. 
2. Only wait 1 second if it's the second network connection attempt 

I tested this locally by reducing the timeout function time to force it to loop. I haven't written a test to test the recursion, I can do that too. 

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
