### PR TITLE
made a clear file function

### DIFF
--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -308,6 +308,9 @@ class Viewer extends React.Component<{}, ViewerState> {
                 <button onClick={() => simulariumController.stop()}>
                     stop
                 </button>
+                <button onClick={() => simulariumController.clearFile()}>
+                    Clear
+                </button>
 
                 <br />
                 <input
@@ -390,7 +393,10 @@ class Viewer extends React.Component<{}, ViewerState> {
                 <button onClick={() => simulariumController.zoomOut()}>
                     -
                 </button>
-                <span>Tick interval length: {simulariumController.tickIntervalLength}</span>
+                <span>
+                    Tick interval length:{" "}
+                    {simulariumController.tickIntervalLength}
+                </span>
                 <div className="viewer-container">
                     <SimulariumViewer
                         ref={this.viewerRef}

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -6,6 +6,7 @@ import {
     VisData,
     VisDataMessage,
     TrajectoryFileInfo,
+    VisGeometry,
 } from "../simularium";
 import {
     SimulariumFileFormat,
@@ -32,6 +33,7 @@ const DEFAULT_ASSET_PREFIX =
 export default class SimulariumController {
     public netConnection: NetConnection | undefined;
     public visData: VisData;
+    public visGeometry: VisGeometry | undefined;
     public tickIntervalLength: number;
     public handleTrajectoryInfo: (TrajectoryFileInfo) => void;
     public postConnect: () => void;
@@ -56,7 +58,6 @@ export default class SimulariumController {
     public constructor(params: SimulariumControllerParams) {
         this.visData = new VisData();
         this.tickIntervalLength = 0; // Will be overwritten when a trajectory is loaded
-
         this.postConnect = () => {
             /* Do Nothing */
         };
@@ -277,6 +278,21 @@ export default class SimulariumController {
         return Promise.resolve({
             status: FILE_STATUS_SUCCESS,
         });
+    }
+
+    public clearFile(): void {
+        this.fileChanged = false;
+        this.playBackFile = "";
+        this.localFile = true; // default
+        this.geometryFile = "";
+        this.assetPrefix = DEFAULT_ASSET_PREFIX;
+        this.visData.clearCache();
+        this.disableNetworkCommands();
+        this.pause();
+        if (this.visGeometry) {
+            this.visGeometry.clearForNewTrajectory();
+            this.visGeometry.resetCamera();
+        }
     }
 
     public changeFile(

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -204,7 +204,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
         simulariumController.centerCamera = this.centerCamera;
         simulariumController.zoomIn = this.zoomIn;
         simulariumController.zoomOut = this.zoomOut;
-
+        simulariumController.visGeometry = this.visGeometry;
         simulariumController.trajFileInfoCallback = (
             msg: TrajectoryFileInfo
         ) => {


### PR DESCRIPTION
In addressing the [clear viewer issue](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1219) on the front end, I realized we don't have a clean way to clear out a file from the viewer. 

@toloudis and @EricJIsaac can you think of any settings I should clear out that I missed? This works visually, but I want to make sure the state of the app is consistent. 


**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
