### PR TITLE
fix bug with highlighting of fibers

### DIFF
--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1391,6 +1391,9 @@ class VisGeometry {
                 return;
             }
 
+            const isHighlighted = this.highlightedIds.includes(visAgent.typeId);
+            visAgent.setHighlighted(isHighlighted);
+
             // if not fiber...
             if (visType === VisTypes.ID_VIS_TYPE_DEFAULT) {
                 // did the agent type change since the last sim time?
@@ -1552,8 +1555,6 @@ class VisGeometry {
                     );
                 }
             }
-            const isHighlighted = this.highlightedIds.includes(visAgent.typeId);
-            visAgent.setHighlighted(isHighlighted);
         });
 
         this.hideUnusedAgents(agents.length);


### PR DESCRIPTION
Bug:  
Load endocytosis.
click to highlight actin.
notice that fiber ends do not highlight.
click to dehighlight. 
fiber ends are now highlighted but fibers are not, anymore.

The fix was to set the highlight state much earlier in the update, before any of the color/geometry/material/rendering-specific updating happens.