### PR TITLE
make sure previous fiber data is copied when reallocation is needed

### DIFF
--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -168,6 +168,23 @@ class Viewer extends React.Component<{}, ViewerState> {
         });
     };
 
+    public loadFromUrl(url): void {
+        fetch(url)
+            .then((item) => {
+                return item.text();
+            })
+            .then((parsedFile) => {
+                const simulariumFile = JSON.parse(parsedFile);
+                const fileName = url;
+                simulariumController
+                    .changeFile({ simulariumFile }, fileName)
+                    .catch((error) => {
+                        console.log("Error loading file", error);
+                        window.alert(`Error loading file: ${error.message}`);
+                    });
+            });
+    }
+
     public handleJsonMeshData(jsonData): void {
         console.log("Mesh JSON Data: ", jsonData);
     }
@@ -281,6 +298,9 @@ class Viewer extends React.Component<{}, ViewerState> {
 
     private configureAndLoad() {
         simulariumController.configureNetwork(netConnectionSettings);
+        if (playbackFile.startsWith("http")) {
+            return this.loadFromUrl(playbackFile);
+        }
         if (playbackFile === "TEST_POINTS") {
             simulariumController.changeFile(
                 {

--- a/src/simularium/VisGeometry/rendering/InstancedFiber.ts
+++ b/src/simularium/VisGeometry/rendering/InstancedFiber.ts
@@ -194,14 +194,20 @@ class InstancedFiber {
         // build new data texture
         // one row per curve, number of colums = num of curve control pts
         // TODO: consolidate space better.
+
+        const newData = new Float32Array(n * this.nCurvePoints * 3);
+        // start by copying the old data into the new array
+        // ASSUMES THERE IS SPACE. This depends on reallocate only growing the array.
+        // Otherwise an exception is thrown.
+        const oldData = this.curveData.image.data;
+        newData.set(oldData);
         this.curveData = new DataTexture(
-            new Float32Array(n * this.nCurvePoints * 3),
+            newData,
             this.nCurvePoints,
             n,
             RGBFormat,
             FloatType
         );
-        // we don't copy the old data texture in here because on every update, we are re-filling it
 
         this.curveGeometry = createTubeGeometry(
             this.nRadialSections,


### PR DESCRIPTION
Problem
=======
Fixes #209 
Fibers were disappearing at certain frames of a trajectory.

Solution
========
Based on a bad assumption, the code that resizes a buffer was not copying the old data into the new buffer.
The fix ensures that old data is carried along when resizing buffer.

I also added code in the test viewer to very simply download a simularium file if the file query string begins with http.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Can reproduce and verify with the simularium files mentioned in #209

