### PR TITLE
add unmodified to displaydata

### DIFF
--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -212,8 +212,19 @@ class SelectionInterface {
             const displayStates: DisplayStateEntry[] = [];
             const encounteredTags: string[] = [];
 
-            this.entries[name].forEach((entry) => {
-                entry.tags.forEach((tag) => {
+            const hasMultipleStates =
+                Object.keys(this.entries[name]).length > 1;
+            this.entries[name].forEach((entry: DecodedTypeEntry) => {
+                // add unmodified state if there are multiple states, and one of them
+                // has no state tags
+                if (!entry.tags.length && hasMultipleStates) {
+                    displayStates.push({
+                        name: "<unmodified>",
+                        id: "", // selects agents with no state tags
+                        color: entry.color,
+                    });
+                }
+                entry.tags.forEach((tag: string) => {
                     if (encounteredTags.includes(tag)) {
                         return;
                     }

--- a/src/test/SelectionInterface.test.ts
+++ b/src/test/SelectionInterface.test.ts
@@ -318,6 +318,71 @@ describe("SelectionInterface module", () => {
 
             si.getUIDisplayData();
         });
+        test("It adds an unmodified state to agents that have one", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const uiDisplayData = si.getUIDisplayData();
+            const uiDisplayDataForA = uiDisplayData.find(
+                (entry) => entry.name === "A"
+            );
+            const uiDisplayDataForB = uiDisplayData.find(
+                (entry) => entry.name === "B"
+            );
+            const uiDisplayDataForC = uiDisplayData.find(
+                (entry) => entry.name === "C"
+            );
+            const unmodifiedDisplayState = {
+                name: "<unmodified>",
+                id: "",
+                color: "",
+            };
+            expect(uiDisplayDataForA?.displayStates.length).toEqual(3);
+            expect(uiDisplayDataForA?.displayStates).toContainEqual(
+                unmodifiedDisplayState
+            );
+            expect(uiDisplayDataForB?.displayStates.length).toEqual(3);
+            expect(uiDisplayDataForB?.displayStates).toContainEqual(
+                unmodifiedDisplayState
+            );
+            expect(uiDisplayDataForC?.displayStates.length).toEqual(3);
+            expect(uiDisplayDataForC?.displayStates).toContainEqual(
+                unmodifiedDisplayState
+            );
+        });
+        test("It doesn't add an unmodified state to agents that don't have one", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const uiDisplayData = si.getUIDisplayData();
+            const uiDisplayDataForE = uiDisplayData.find(
+                (entry) => entry.name === "E"
+            );
+            const unmodifiedDisplayState = {
+                name: "<unmodified>",
+                id: "",
+                color: "",
+            };
+            expect(uiDisplayDataForE?.displayStates.length).toEqual(1);
+            expect(uiDisplayDataForE?.displayStates).not.toContainEqual(
+                unmodifiedDisplayState
+            );
+        });
+        test("It doesn't include unmodified state if there are no other tags", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const uiDisplayData = si.getUIDisplayData();
+            const uiDisplayDataForD = uiDisplayData.find(
+                (entry) => entry.name === "D"
+            );
+            const unmodifiedDisplayState = {
+                name: "<unmodified>",
+                id: "",
+                color: "",
+            };
+            expect(uiDisplayDataForD?.displayStates.length).toEqual(0);
+            expect(uiDisplayDataForD?.displayStates).not.toContainEqual(
+                unmodifiedDisplayState
+            );
+        });
     });
 
     describe("setAgentColors", () => {


### PR DESCRIPTION
Problem
=======
Not all trajectories have unmodified state for agents.

[Pair with this PR](https://github.com/allen-cell-animated/simularium-website/pull/265)
closes [this issue](https://github.com/allen-cell-animated/simularium-website/issues/263)

Solution
========
Send in the unmodified display state with the uiDisplayData instead of adding it on the front end

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* This change requires updated or new tests

Change summary:
---------------
* add unmodified to displaydata

Steps to Verify:
----------------
1. npm start
2. the example app uiDisplayData will have <unmodified> included in it's data when appropriate, use  actin012_3_obj-local-url_arp2-green_arp3-pink_actin-purple.simularium as an example.

Screenshots (optional):
-----------------------
installed this build in the front end:
<img width="267" alt="Screen Shot 2021-10-21 at 1 17 22 PM" src="https://user-images.githubusercontent.com/5170636/138351273-35c8fb82-5fd9-4df0-8da3-85dff68ae067.png">


