### PR TITLE
Fix/frame time issues when streamed trajectory doesn't start at t=0

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -259,6 +259,7 @@ export default class SimulariumController {
         this.isFileChanging = false;
         this.playBackFile = "";
         this.visData.clearCache();
+        this.visData.firstFrameTime = -1;
         this.disableNetworkCommands();
         this.pause();
         if (this.visGeometry) {
@@ -274,6 +275,7 @@ export default class SimulariumController {
     ): Promise<FileReturn> {
         this.isFileChanging = true;
         this.playBackFile = newFileName;
+        this.visData.firstFrameTime = -1;
 
         if (this.simulator instanceof RemoteSimulator) {
             this.simulator.handleError = () => noop;

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -230,6 +230,15 @@ export default class SimulariumController {
                 // else reset the local cache,
                 //  and play remotely from the desired simulation time
                 this.visData.clearCache();
+
+                // Instead of requesting from the backend the `time` passed into this
+                // function, we request (time - firstFrameTime) because the backend
+                // currently assumes the first frame of every trajectory is at time 0.
+                //
+                // TODO: Long term, we should decide on a better way to deal with this
+                // assumption: remove assumption from backend, perform this normalization
+                // in simulariumio, or something else? One way might be to require making
+                // firstFrameTime a part of TrajectoryFileInfo.
                 let firstFrameTime = this.visData.firstFrameTime;
                 if (firstFrameTime === -1) {
                     console.error(

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -267,8 +267,7 @@ export default class SimulariumController {
     public clearFile(): void {
         this.isFileChanging = false;
         this.playBackFile = "";
-        this.visData.clearCache();
-        this.visData.firstFrameTime = null;
+        this.visData.clearForNewTrajectory();
         this.disableNetworkCommands();
         this.pause();
         if (this.visGeometry) {
@@ -284,14 +283,13 @@ export default class SimulariumController {
     ): Promise<FileReturn> {
         this.isFileChanging = true;
         this.playBackFile = newFileName;
-        this.visData.firstFrameTime = null;
 
         if (this.simulator instanceof RemoteSimulator) {
             this.simulator.handleError = () => noop;
         }
 
         this.visData.WaitForFrame(0);
-        this.visData.clearCache();
+        this.visData.clearForNewTrajectory();
         this.visData.cancelAllWorkers();
 
         this.stop();

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -236,7 +236,11 @@ export default class SimulariumController {
                 // Revert the 2 lines of code below to:
                 // this.simulator.gotoRemoteSimulationTime(time);
                 const roundedTime = parseFloat(time.toPrecision(4));
-                this.simulator.gotoRemoteSimulationTime(roundedTime);
+                console.log({ roundedTime });
+                console.log("firstFrameTime:", this.visData.firstFrameTime);
+                this.simulator.gotoRemoteSimulationTime(
+                    roundedTime - this.visData.firstFrameTime
+                );
             }
         }
     }

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -240,7 +240,7 @@ export default class SimulariumController {
                 // in simulariumio, or something else? One way might be to require making
                 // firstFrameTime a part of TrajectoryFileInfo.
                 let firstFrameTime = this.visData.firstFrameTime;
-                if (firstFrameTime === -1) {
+                if (firstFrameTime === null) {
                     console.error(
                         "VisData does not contain firstFrameTime, defaulting to 0"
                     );
@@ -268,7 +268,7 @@ export default class SimulariumController {
         this.isFileChanging = false;
         this.playBackFile = "";
         this.visData.clearCache();
-        this.visData.firstFrameTime = -1;
+        this.visData.firstFrameTime = null;
         this.disableNetworkCommands();
         this.pause();
         if (this.visGeometry) {
@@ -284,7 +284,7 @@ export default class SimulariumController {
     ): Promise<FileReturn> {
         this.isFileChanging = true;
         this.playBackFile = newFileName;
-        this.visData.firstFrameTime = -1;
+        this.visData.firstFrameTime = null;
 
         if (this.simulator instanceof RemoteSimulator) {
             this.simulator.handleError = () => noop;

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -230,9 +230,14 @@ export default class SimulariumController {
                 // else reset the local cache,
                 //  and play remotely from the desired simulation time
                 this.visData.clearCache();
-                this.simulator.gotoRemoteSimulationTime(
-                    time - this.visData.firstFrameTime
-                );
+                let firstFrameTime = this.visData.firstFrameTime;
+                if (firstFrameTime === -1) {
+                    console.error(
+                        "VisData does not contain firstFrameTime, defaulting to 0"
+                    );
+                    firstFrameTime = 0;
+                }
+                this.simulator.gotoRemoteSimulationTime(time - firstFrameTime);
             }
         }
     }

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -230,16 +230,8 @@ export default class SimulariumController {
                 // else reset the local cache,
                 //  and play remotely from the desired simulation time
                 this.visData.clearCache();
-
-                // NOTE: This arbitrary rounding of time is a temporary fix until
-                // simularium-engine is updated to work with imprecise float time values.
-                // Revert the 2 lines of code below to:
-                // this.simulator.gotoRemoteSimulationTime(time);
-                const roundedTime = parseFloat(time.toPrecision(4));
-                console.log({ roundedTime });
-                console.log("firstFrameTime:", this.visData.firstFrameTime);
                 this.simulator.gotoRemoteSimulationTime(
-                    roundedTime - this.visData.firstFrameTime
+                    time - this.visData.firstFrameTime
                 );
             }
         }

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -460,6 +460,11 @@ class VisData {
         this.netBuffer = new ArrayBuffer(0);
     }
 
+    public clearForNewTrajectory(): void {
+        this.clearCache();
+        this.firstFrameTime = null;
+    }
+
     public cancelAllWorkers(): void {
         // we need to be able to terminate any queued work in the worker during trajectory changeovers
         if (

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -41,7 +41,6 @@ class VisData {
     private frameCache: AgentData[][];
     private frameDataCache: FrameData[];
     private webWorker: Worker | null;
-    public firstFrameTime: number;
 
     private frameToWaitFor: number;
     private lockedForFrame: boolean;
@@ -51,6 +50,7 @@ class VisData {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private _dragAndDropFileInfo: TrajectoryFileInfo | null;
 
+    public firstFrameTime: number;
     public timeStepSize: number;
 
     /**

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -471,6 +471,18 @@ class VisData {
         }
     }
 
+    // Add parsed frames to the cache and save the timestamp of the first frame
+    private addFramesToCache(frames: ParsedBundle): void {
+        Array.prototype.push.apply(this.frameDataCache, frames.frameDataArray);
+        Array.prototype.push.apply(
+            this.frameCache,
+            frames.parsedAgentDataArray
+        );
+        if (this.firstFrameTime === -1) {
+            this.firstFrameTime = frames.frameDataArray[0].time;
+        }
+    }
+
     public parseAgentsFromNetData(msg: VisDataMessage | ArrayBuffer): void {
         if (msg instanceof ArrayBuffer) {
             const floatView = new Float32Array(msg);
@@ -513,17 +525,7 @@ class VisData {
             this.webWorker.postMessage(visDataMsg);
         } else {
             const frames = VisData.parse(visDataMsg);
-            Array.prototype.push.apply(
-                this.frameDataCache,
-                frames.frameDataArray
-            );
-            Array.prototype.push.apply(
-                this.frameCache,
-                frames.parsedAgentDataArray
-            );
-            if (this.firstFrameTime === -1) {
-                this.firstFrameTime = frames.frameDataArray[0].time;
-            }
+            this.addFramesToCache(frames);
         }
     }
 
@@ -564,19 +566,7 @@ class VisData {
             ) {
                 this.clearCache(); // new data has arrived
             }
-
-            Array.prototype.push.apply(
-                this.frameDataCache,
-                frames.frameDataArray
-            );
-            Array.prototype.push.apply(
-                this.frameCache,
-                frames.parsedAgentDataArray
-            );
-
-            if (this.firstFrameTime === -1) {
-                this.firstFrameTime = frames.frameDataArray[0].time;
-            }
+            this.addFramesToCache(frames);
 
             // Save remaining data for later processing
             const remainder = data.slice(eof + eofPhrase.length);
@@ -609,14 +599,7 @@ class VisData {
         }
 
         const frames = VisData.parse(visDataMsg);
-        Array.prototype.push.apply(this.frameDataCache, frames.frameDataArray);
-        Array.prototype.push.apply(
-            this.frameCache,
-            frames.parsedAgentDataArray
-        );
-        if (this.firstFrameTime === -1) {
-            this.firstFrameTime = frames.frameDataArray[0].time;
-        }
+        this.addFramesToCache(frames);
     }
 
     public set dragAndDropFileInfo(fileInfo: TrajectoryFileInfo | null) {

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -41,6 +41,7 @@ class VisData {
     private frameCache: AgentData[][];
     private frameDataCache: FrameData[];
     private webWorker: Worker | null;
+    public firstFrameTime: number;
 
     private frameToWaitFor: number;
     private lockedForFrame: boolean;
@@ -357,6 +358,7 @@ class VisData {
         }
         this.frameCache = [];
         this.frameDataCache = [];
+        this.firstFrameTime = -1;
         this.cacheFrame = -1;
         this._dragAndDropFileInfo = null;
         this.frameToWaitFor = 0;
@@ -519,6 +521,9 @@ class VisData {
                 this.frameCache,
                 frames.parsedAgentDataArray
             );
+            if (this.firstFrameTime === -1) {
+                this.firstFrameTime = frames.frameDataArray[0].time;
+            }
         }
     }
 
@@ -569,6 +574,10 @@ class VisData {
                 frames.parsedAgentDataArray
             );
 
+            if (this.firstFrameTime === -1) {
+                this.firstFrameTime = frames.frameDataArray[0].time;
+            }
+
             // Save remaining data for later processing
             const remainder = data.slice(eof + eofPhrase.length);
             this.netBuffer = new ArrayBuffer(remainder.byteLength);
@@ -605,6 +614,9 @@ class VisData {
             this.frameCache,
             frames.parsedAgentDataArray
         );
+        if (this.firstFrameTime === -1) {
+            this.firstFrameTime = frames.frameDataArray[0].time;
+        }
     }
 
     public set dragAndDropFileInfo(fileInfo: TrajectoryFileInfo | null) {

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -50,7 +50,7 @@ class VisData {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private _dragAndDropFileInfo: TrajectoryFileInfo | null;
 
-    public firstFrameTime: number;
+    public firstFrameTime: number | null;
     public timeStepSize: number;
 
     /**
@@ -358,7 +358,7 @@ class VisData {
         }
         this.frameCache = [];
         this.frameDataCache = [];
-        this.firstFrameTime = -1; // Assumes negative timestamps don't exist
+        this.firstFrameTime = null;
         this.cacheFrame = -1;
         this._dragAndDropFileInfo = null;
         this.frameToWaitFor = 0;
@@ -478,7 +478,7 @@ class VisData {
             this.frameCache,
             frames.parsedAgentDataArray
         );
-        if (this.firstFrameTime === -1) {
+        if (this.firstFrameTime === null) {
             this.firstFrameTime = frames.frameDataArray[0].time;
         }
     }

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -358,7 +358,7 @@ class VisData {
         }
         this.frameCache = [];
         this.frameDataCache = [];
-        this.firstFrameTime = -1;
+        this.firstFrameTime = -1; // Assumes negative timestamps don't exist
         this.cacheFrame = -1;
         this._dragAndDropFileInfo = null;
         this.frameToWaitFor = 0;


### PR DESCRIPTION
Problem
=======
Closes #234 

The above bug was being caused because the backend incorrectly assumes that all trajectories start at t = 0. This is the quickest way to patch the issue so that endocytosis can be successfully streamed again, while we work out a better long-term solution.

Solution
========
* Grab the first frame's timestamp when a new trajectory arrives from the backend and VisData parses that data into frames, and save that as `firstFrameTime`, a property of class `VisData`. 
* When requesting a frame at a specific time from the backend, request the frame at `time - firstFrameTime` instead of `time` to compensate for the backend assumption that trajectories start at time 0.

Thank you @toloudis for finding the root of the issue in the backend and suggesting this fix!

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Pull this branch, and try streaming endocytosis in the viewer testbed. Skipping frames forward and backward should successfully increment or decrement by 0.1.
2. Install this in simularium-website and make sure it works when wrapped in simularium-website as well
3. Other streamed and drag and drop trajectories should work without problem as before.
