### PR TITLE
fix focus when fiber was clicked by checking for correct type

### DIFF
--- a/src/simularium/VisGeometry/VisAgent.ts
+++ b/src/simularium/VisGeometry/VisAgent.ts
@@ -158,7 +158,7 @@ export default class VisAgent {
 
     public getFollowPosition(): Vector3 {
         if (
-            this.agentData.visType === VisTypes.ID_VIS_TYPE_FIBER &&
+            this.agentData["vis-type"] === VisTypes.ID_VIS_TYPE_FIBER &&
             this.fiberCurve
         ) {
             return this.fiberCurve.getPoint(0.5);


### PR DESCRIPTION
Problem
=======
Clicking on fibers when in focus mode does not move the camera at all.  Fixing #239 

Solution
========
The code was checking for an incorrect property name on the agent data.  Fixing the property name allows focus mode to work as originally coded.  It will focus on the mid-point of the fiber curve.  

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Load trajectory with fiber data
2. click on one of the fibers when follow mode is active.
3. camera should animate to the center of the curve

