### PR TITLE
Prototype movie saving

### DIFF
--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -75,6 +75,7 @@ interface ViewerState {
     totalDuration: number;
     uiDisplayData: UIDisplayData;
     recordingTime: number; // in seconds
+    videoOutputStatus: string;
 }
 
 const simulariumController = new SimulariumController({});
@@ -102,6 +103,7 @@ const initialState = {
         hiddenAgents: [],
     },
     recordingTime: 0,
+    videoOutputStatus: "",
 };
 
 class Viewer extends React.Component<{}, ViewerState> {
@@ -150,6 +152,9 @@ class Viewer extends React.Component<{}, ViewerState> {
     }
 
     private handleVideoDataAvailable = async (event: BlobEvent) => {
+        this.setState({
+            videoOutputStatus: "Processing..."
+        });
         console.log("Video data available:", event.data)
         // Following example from:
         // https://github.com/ffmpegwasm/react-app/blob/master/src/App.js
@@ -165,7 +170,9 @@ class Viewer extends React.Component<{}, ViewerState> {
         }
         const mp4Data = await transcodeToMp4(webmBlob);
         const mp4Blob = new Blob([mp4Data.buffer], { type: "video/mp4" });
-        console.log(`Size of output video: ${mp4Blob.size / 1000} KB`);
+        this.setState({
+            videoOutputStatus: `Video file size: ${mp4Blob.size / 1000} KB`
+        });
         const url = URL.createObjectURL(mp4Blob);
         let a = document.createElement("a");
         document.body.appendChild(a);
@@ -374,7 +381,10 @@ class Viewer extends React.Component<{}, ViewerState> {
         // this.mediaRecorder.start() completes.
 
         // simulariumController.pause();
-        this.setState({ recordingTime: 0 });
+        this.setState({ 
+            recordingTime: 0,
+            videoOutputStatus: ""
+        });
         this.mediaRecorder.start();
         this.recordingTimerId = setInterval(() => this.setState({
             recordingTime: this.state.recordingTime + 1
@@ -506,9 +516,12 @@ class Viewer extends React.Component<{}, ViewerState> {
                 <button onClick={this.stopRecording.bind(this)}>
                     Stop Recording
                 </button>
-                <span>
-                    {this.state.recordingTime ? `Recording length: ${this.state.recordingTime} s` : ""}
-                </span>
+                {this.state.recordingTime > 0 &&
+                    <span>Recording length: {this.state.recordingTime} s</span>
+                }
+                {this.state.videoOutputStatus &&
+                    <span>{" "}|{" "}{this.state.videoOutputStatus}</span>
+                }
                 <br />
                 {this.state.particleTypeNames.map((id, i) => {
                     return (

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -358,7 +358,15 @@ class Viewer extends React.Component<{}, ViewerState> {
     }
 
     private startRecording(): void {
+        // FIXME: The viewer breaks if recording begins while trajectory is playing.
+        // One possible workaround is to pause before recording start, then resume
+        // after recording starts, but it results in a slo-mo part in the middle
+        // of the exported video. It might be because we need to wait until 
+        // this.mediaRecorder.start() completes.
+
+        // simulariumController.pause();
         this.mediaRecorder.start();
+        // simulariumController.resume();
     }
 
     private stopRecording(): void {

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -134,7 +134,8 @@ class Viewer extends React.Component<{}, ViewerState> {
         const canvasEl = document.querySelector("canvas");
         const stream = canvasEl.captureStream();
         this.mediaRecorder = new MediaRecorder(stream, {
-            mimeType: "video/webm"
+            mimeType: "video/webm; codecs=vp9",
+            videoBitsPerSecond: 5000000
         });
         this.mediaRecorder.ondataavailable = (event) => {
             console.log("data available:", event.data)
@@ -459,6 +460,7 @@ class Viewer extends React.Component<{}, ViewerState> {
                 <label htmlFor="slider">
                     {this.state.currentTime} / {this.state.totalDuration}
                 </label>
+                <br/>
                 <button onClick={this.startRecording.bind(this)}>
                     Start Recording
                 </button>

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -141,7 +141,7 @@ class Viewer extends React.Component<{}, ViewerState> {
         const canvasEl = document.querySelector("canvas");
         const stream = canvasEl.captureStream();
         this.mediaRecorder = new MediaRecorder(stream, {
-            mimeType: "video/webm; codecs=vp9",
+            mimeType: "video/webm",
             // Default of 2.5 Mbps is unsatisfactory
             videoBitsPerSecond: 5000000
         });

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -362,6 +362,7 @@ class Viewer extends React.Component<{}, ViewerState> {
     }
 
     private stopRecording(): void {
+        simulariumController.pause();
         this.mediaRecorder.stop();
     }
 

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -130,6 +130,7 @@ class Viewer extends React.Component<{}, ViewerState> {
             viewerContainer.addEventListener("dragover", this.onDragOver);
         }
 
+        // https://developer.mozilla.org/en-US/docs/Web/API/MediaStream_Recording_API#overview_of_the_recording_process
         const canvasEl = document.querySelector("canvas");
         const stream = canvasEl.captureStream();
         this.mediaRecorder = new MediaRecorder(stream, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1444,6 +1444,22 @@
                 }
             }
         },
+        "@ffmpeg/core": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.10.0.tgz",
+            "integrity": "sha512-qunWJl5PezpXEm31tb8Qu5z37B5KVA1VYZCpXchMhuAb3X9T7PuE3SlhOwphEoRhzaOa3lpofDfzihAUMFaVPQ=="
+        },
+        "@ffmpeg/ffmpeg": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
+            "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
+            "requires": {
+                "is-url": "^1.2.4",
+                "node-fetch": "^2.6.1",
+                "regenerator-runtime": "^0.13.7",
+                "resolve-url": "^0.2.1"
+            }
+        },
         "@fortawesome/fontawesome-common-types": {
             "version": "0.2.36",
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
@@ -8236,6 +8252,11 @@
             "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true
         },
+        "is-url": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+        },
         "is-weakref": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -12711,7 +12732,6 @@
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
             "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dev": true,
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
@@ -15141,8 +15161,7 @@
         "regenerator-runtime": {
             "version": "0.13.9",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-            "dev": true
+            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         },
         "regenerator-transform": {
             "version": "0.14.5",
@@ -15315,8 +15334,7 @@
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "dev": true
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "resolve.exports": {
             "version": "1.1.0",
@@ -16541,8 +16559,7 @@
         "tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-            "dev": true
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
         },
         "ts-jest": {
             "version": "27.1.2",
@@ -17005,8 +17022,7 @@
         "webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-            "dev": true
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "webpack": {
             "version": "5.65.0",
@@ -17371,7 +17387,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "dev": true,
             "requires": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1445,14 +1445,14 @@
             }
         },
         "@ffmpeg/core": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.10.0.tgz",
-            "integrity": "sha512-qunWJl5PezpXEm31tb8Qu5z37B5KVA1VYZCpXchMhuAb3X9T7PuE3SlhOwphEoRhzaOa3lpofDfzihAUMFaVPQ=="
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.8.5.tgz",
+            "integrity": "sha512-hemVFmhVLbD/VZaCG2BvCzFglKytMIMJ5aJfc12eXN4O4cG0wXnGTMVzlK1KKW/6viHhJMPkc9h4UDnJW8Uivg=="
         },
         "@ffmpeg/ffmpeg": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
-            "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
+            "version": "0.9.8",
+            "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.9.8.tgz",
+            "integrity": "sha512-QradleJx78hHJBtI1wRsus1L1jxQB3v4h6k8c3CERI9fssm+NSSppuofmsOei7uq7iQEYq3oK9tJNAyEsRoNng==",
             "requires": {
                 "is-url": "^1.2.4",
                 "node-fetch": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
         "react-dom": "^16.9.0"
     },
     "dependencies": {
-        "@ffmpeg/core": "^0.10.0",
-        "@ffmpeg/ffmpeg": "^0.10.1",
+        "@ffmpeg/core": "^0.8.3",
+        "@ffmpeg/ffmpeg": "^0.9.4",
         "@fortawesome/fontawesome-free": "^5.15.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.34",
         "@fortawesome/free-solid-svg-icons": "^5.15.2",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,8 @@
         "react-dom": "^16.9.0"
     },
     "dependencies": {
+        "@ffmpeg/core": "^0.10.0",
+        "@ffmpeg/ffmpeg": "^0.10.1",
         "@fortawesome/fontawesome-free": "^5.15.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.34",
         "@fortawesome/free-solid-svg-icons": "^5.15.2",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -33,6 +33,8 @@ module.exports = {
         },
         open: ["public/"],
         allowedHosts: "all",
+        // See note about SharedArrayBuffer under "Browser":
+        // https://github.com/ffmpegwasm/ffmpeg.wasm#installation
         headers: {
             'Cross-Origin-Embedder-Policy': 'require-corp',
             "Cross-Origin-Opener-Policy": "same-origin"

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -33,7 +33,7 @@ module.exports = {
         },
         open: ["public/"],
         allowedHosts: "all",
-        // See note about SharedArrayBuffer under "Browser":
+        // These headers enable SharedArrayBuffer for ffmpeg. Look under "Browser":
         // https://github.com/ffmpegwasm/ffmpeg.wasm#installation
         headers: {
             'Cross-Origin-Embedder-Policy': 'require-corp',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -33,6 +33,10 @@ module.exports = {
         },
         open: ["public/"],
         allowedHosts: "all",
+        headers: {
+            'Cross-Origin-Embedder-Policy': 'require-corp',
+            "Cross-Origin-Opener-Policy": "same-origin"
+        }
     },
     module: {
         rules: [


### PR DESCRIPTION
Problem
=======
Closes #240 

Solution
========
Bare-bones test implementation -- Use the [MediaRecorder API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API) to capture canvas frames as a webm video and [ffmpeg.wasm](https://github.com/ffmpegwasm/ffmpeg.wasm#ffmpegwasm) to convert it to an mp4 file before downloading it to the user's machine.

### Some questions that were answered through prototyping:
* Can we output videos of satisfactory quality?
    * Yes it seems we can raise the quality of the output video by raising `videoBitsPerSecond` where we instantiate a `new MediaRecorder`
* Can we output videos as mp4 files?
    * Yes it is possible with ffmpeg.wasm (web version of ffmpeg) 
* Can we display the clock duration of the recording to the user while recording?
    * Yes I have implemented a duration indicator using basic `setInterval()` but there might be a better way to do this. I found sometimes I'm off by 1 second with the current implementation.
* Can we display file size in a modal before the user confirms they want to download the file?
    * Yes, we should be able to, but depending on the user's browser setting the browser will also do this for us automatically.
* Can we display a progress indicator while the file is processing?
    * Yes it seems like we should be able to with ffmpeg (the transcoding to mp4 makes up almost all of the processing time): https://github.com/ffmpegwasm/ffmpeg.wasm/blob/master/docs/api.md#createffmpegoptions-ffmpeg

### Remaining issues to address
* ffmpeg requires [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) to be enabled which requires a page to be "cross-origin isolated"... I was able to make it with the dev server work by supplying in the necessary headers but not sure how it would work for non-dev environment. See note under "Browser" in the [ffmpeg readme](https://github.com/ffmpegwasm/ffmpeg.wasm#installation)
* I think these two issues only arise with ffmpeg in use but I'm not 100% positive:
    * Current implementation breaks the page if I stop recording while a trajectory is still playing. I got around this for now by forcing the trajectory to pause first when "Stop Recording" button is pressed
    * Current implementation fails (output video is empty) if I start playing the trajectory before pressing the "Start Recording" button. I tried one solution which was to pause the trajectory, start recording, then resume the trajectory playback anytime the Start Recording button is clicked, but that resulted in videos with a slo-mo part in the middle. I think this might be some kind of race condition? And/or something to do with a variable frame rate: https://video.stackexchange.com/questions/24576/output-of-ffmpeg-has-a-slow-motion-part-what-is-it-and-how-to-avoid/24578#24578

## Type of change
Please delete options that are not relevant.

* Proto-New feature (non-breaking change which adds functionality)

Screenshots (optional):
-----------------------
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/12690133/157347362-f3287e14-88db-43ec-a996-3c0c4942d9c2.png">