### PR TITLE
download biological unit from pdb

### DIFF
--- a/src/visGeometry/GeometryStore.ts
+++ b/src/visGeometry/GeometryStore.ts
@@ -221,7 +221,7 @@ class GeometryStore {
             // TODO:
             // Can we confirm that the rcsb.org servers have every id as a cif file?
             // If so, then we don't need to do this second try and we can always use .cif.
-            actualUrl = `https://files.rcsb.org/download/${pdbID}.cif`;
+            actualUrl = `https://files.rcsb.org/download/${pdbID}-assembly1.cif`;
         }
         return fetch(actualUrl)
             .then((response) => {
@@ -229,7 +229,7 @@ class GeometryStore {
                     return response.text();
                 } else if (pdbID) {
                     // try again as pdb
-                    actualUrl = `https://files.rcsb.org/download/${pdbID}.pdb`;
+                    actualUrl = `https://files.rcsb.org/download/${pdbID}.pdb1`;
                     return fetch(actualUrl).then((response) => {
                         if (!response.ok) {
                             // error will be caught by the function that calls this


### PR DESCRIPTION
Problem
=======
We want to be downloading the biological unit, not the asymentrical unit from the pdb 

Solution
========
changed the urls https://www.rcsb.org/docs/programmatic-access/file-download-services#pdb-entry-files

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Screenshots (optional):
-----------------------
For this pdb structure: https://www.rcsb.org/structure/3GHG
<img width="345" alt="Screen Shot 2022-07-19 at 4 29 31 PM" src="https://user-images.githubusercontent.com/5170636/179865069-fe21a41e-7133-4568-b33d-4572ecc0c39e.png">
<img width="367" alt="Screen Shot 2022-07-19 at 4 29 48 PM" src="https://user-images.githubusercontent.com/5170636/179865074-55c424c6-4cd2-48c9-9bbe-0c4d972503e5.png">
