### PR TITLE
Feature/improve cif loader

### DIFF
--- a/examples/SinglePdbSimulator.ts
+++ b/examples/SinglePdbSimulator.ts
@@ -1,0 +1,121 @@
+import {
+    IClientSimulatorImpl,
+    ClientMessageEnum,
+} from "../src/simularium/localSimulators/IClientSimulatorImpl";
+import {
+    EncodedTypeMapping,
+    TrajectoryFileInfo,
+    VisDataMessage,
+} from "../src/simularium/types";
+import VisTypes from "../src/simularium/VisTypes";
+import { GeometryDisplayType } from "../src/visGeometry/types";
+
+export default class PdbSim implements IClientSimulatorImpl {
+    pdbType: string;
+    size: [number, number, number];
+    agentdata: number[];
+
+    constructor(pdbType: string) {
+        this.pdbType = pdbType;
+        this.size = [25, 25, 25];
+        // 11 is the number of numbers for each agent
+        this.agentdata = new Array(11);
+    }
+
+    public update(_dt: number): VisDataMessage {
+        // fill agent data.
+
+        this.agentdata[0] = VisTypes.ID_VIS_TYPE_DEFAULT; // vis type
+        this.agentdata[1] = 0; // instance id
+        this.agentdata[2] = 0; // type
+        this.agentdata[3] = 0; // x
+        this.agentdata[4] = 0; // y
+        this.agentdata[5] = 0; // z
+        this.agentdata[6] = 0; // rx
+        this.agentdata[7] = 0; // ry
+        this.agentdata[8] = 0; // rz
+        this.agentdata[9] = 1.0; // collision radius
+        this.agentdata[10] = 0; // subpoints
+        const frameData: VisDataMessage = {
+            // TODO get msgType out of here
+            msgType: ClientMessageEnum.ID_VIS_DATA_ARRIVE,
+            bundleStart: 0,
+            bundleSize: 1, // frames
+            bundleData: [
+                {
+                    data: this.agentdata,
+                    frameNumber: 0,
+                    time: 0,
+                },
+            ],
+            fileName: "hello world",
+        };
+        return frameData;
+    }
+
+    public getInfo(): TrajectoryFileInfo {
+        const typeMapping: EncodedTypeMapping = {
+            [0]: {
+                name: this.pdbType,
+                geometry: {
+                    displayType: GeometryDisplayType.PDB,
+                    url: this.pdbType,
+                    color: "ffffff",
+                },
+            },
+        };
+        const FOV_DEGREES = 75;
+        const DEGREES_TO_RADIANS = 3.14159265 / 180.0;
+        return {
+            // TODO get msgType and connId out of here
+            connId: "hello world",
+            msgType: ClientMessageEnum.ID_TRAJECTORY_FILE_INFO,
+            version: 2,
+            timeStepSize: 1,
+            totalSteps: 1,
+            // bounding volume dimensions
+            size: {
+                x: this.size[0],
+                y: this.size[1],
+                z: this.size[2],
+            },
+            cameraDefault: {
+                position: {
+                    x: 0,
+                    y: 0,
+                    z:
+                        // set a z value that will roughly frame the bounding box within our camera field of view
+                        Math.sqrt(
+                            this.size[0] * this.size[0] +
+                                this.size[1] * this.size[1] +
+                                this.size[2] * this.size[2]
+                        ) * Math.tan(0.5 * FOV_DEGREES * DEGREES_TO_RADIANS),
+                },
+                lookAtPosition: {
+                    x: 0,
+                    y: 0,
+                    z: 0,
+                },
+                upVector: {
+                    x: 0,
+                    y: 1,
+                    z: 0,
+                },
+                fovDegrees: FOV_DEGREES,
+            },
+            typeMapping: typeMapping,
+            spatialUnits: {
+                magnitude: 1,
+                name: "m",
+            },
+            timeUnits: {
+                magnitude: 1,
+                name: "s",
+            },
+        };
+    }
+
+    updateSimulationState(data: Record<string, unknown>) {
+        // no op
+    }
+}

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -18,6 +18,7 @@ import "../style/style.css";
 import PointSimulator from "./PointSimulator";
 import PointSimulatorLive from "./PointSimulatorLive";
 import PdbSimulator from "./PdbSimulator";
+import SinglePdbSimulator from "./SinglePdbSimulator";
 import CurveSimulator from "./CurveSimulator";
 import MetaballSimulator from "./MetaballSimulator";
 
@@ -384,6 +385,13 @@ class Viewer extends React.Component<{}, ViewerState> {
                 },
                 playbackFile
             );
+        } else if (playbackFile === "TEST_SINGLE_PDB") {
+            simulariumController.changeFile(
+                {
+                    clientSimulator: new SinglePdbSimulator("3IRL"),
+                },
+                playbackFile
+            );
         } else if (playbackFile === "TEST_METABALLS") {
             simulariumController.changeFile(
                 {
@@ -441,6 +449,7 @@ class Viewer extends React.Component<{}, ViewerState> {
                     <option value="ATPsynthase_8.h5">ATP 8</option>
                     <option value="ATPsynthase_9.h5">ATP 9</option>
                     <option value="ATPsynthase_10.h5">ATP 10</option>
+                    <option value="TEST_SINGLE_PDB">TEST SINGLE PDB</option>
                     <option value="TEST_PDB">TEST PDB</option>
                     <option value="TEST_FIBERS">TEST FIBERS</option>
                     <option value="TEST_POINTS">TEST POINTS</option>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3001,62 +3001,11 @@
                 }
             }
         },
-        "@jridgewell/gen-mapping": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-            "dev": true,
-            "requires": {
-                "@jridgewell/set-array": "^1.0.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
-            },
-            "dependencies": {
-                "@jridgewell/trace-mapping": {
-                    "version": "0.3.14",
-                    "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-                    "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
-                    "dev": true,
-                    "requires": {
-                        "@jridgewell/resolve-uri": "^3.0.3",
-                        "@jridgewell/sourcemap-codec": "^1.4.10"
-                    }
-                }
-            }
-        },
         "@jridgewell/resolve-uri": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
             "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
             "dev": true
-        },
-        "@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-            "dev": true
-        },
-        "@jridgewell/source-map": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-            "dev": true,
-            "requires": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
-            },
-            "dependencies": {
-                "@jridgewell/trace-mapping": {
-                    "version": "0.3.14",
-                    "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-                    "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
-                    "dev": true,
-                    "requires": {
-                        "@jridgewell/resolve-uri": "^3.0.3",
-                        "@jridgewell/sourcemap-codec": "^1.4.10"
-                    }
-                }
-            }
         },
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.11",
@@ -13421,11 +13370,6 @@
                 "json-parse-better-errors": "^1.0.1"
             }
         },
-        "parse-mmcif": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/parse-mmcif/-/parse-mmcif-0.0.1.tgz",
-            "integrity": "sha512-Pb5CovJ5lPaqbO+kbRXwp5CmAoz72ggn5r7c88I73eoCRTSuAx1FJ1g/OjQjqsdgibipdpNYYMYMDivQ659D9Q=="
-        },
         "parse-pdb": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-pdb/-/parse-pdb-1.0.0.tgz",
@@ -16457,21 +16401,33 @@
             }
         },
         "terser": {
-            "version": "5.14.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+            "version": "5.12.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.0.tgz",
+            "integrity": "sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==",
             "dev": true,
             "requires": {
-                "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
+                "source-map": "~0.7.2",
                 "source-map-support": "~0.5.20"
             },
             "dependencies": {
+                "acorn": {
+                    "version": "8.7.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+                    "dev": true
+                },
                 "commander": {
                     "version": "2.20.3",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
                     "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
                     "dev": true
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3001,11 +3001,62 @@
                 }
             }
         },
+        "@jridgewell/gen-mapping": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            },
+            "dependencies": {
+                "@jridgewell/trace-mapping": {
+                    "version": "0.3.14",
+                    "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+                    "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jridgewell/resolve-uri": "^3.0.3",
+                        "@jridgewell/sourcemap-codec": "^1.4.10"
+                    }
+                }
+            }
+        },
         "@jridgewell/resolve-uri": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
             "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
             "dev": true
+        },
+        "@jridgewell/set-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true
+        },
+        "@jridgewell/source-map": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            },
+            "dependencies": {
+                "@jridgewell/trace-mapping": {
+                    "version": "0.3.14",
+                    "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+                    "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jridgewell/resolve-uri": "^3.0.3",
+                        "@jridgewell/sourcemap-codec": "^1.4.10"
+                    }
+                }
+            }
         },
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.11",
@@ -16406,33 +16457,21 @@
             }
         },
         "terser": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.0.tgz",
-            "integrity": "sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==",
+            "version": "5.14.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
             "dev": true,
             "requires": {
+                "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
                 "commander": "^2.20.0",
-                "source-map": "~0.7.2",
                 "source-map-support": "~0.5.20"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "8.7.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-                    "dev": true
-                },
                 "commander": {
                     "version": "2.20.3",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
                     "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.7.3",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
         "@tweakpane/plugin-essentials": "^0.1.4",
         "comlink": "^4.3.1",
         "js-logger": "^1.6.1",
-        "parse-mmcif": "^0.0.1",
         "parse-pdb": "^1.0.0",
         "si-prefix": "^0.2.0",
         "three": "^0.137.4",

--- a/src/visGeometry/GeometryStore.ts
+++ b/src/visGeometry/GeometryStore.ts
@@ -222,7 +222,7 @@ class GeometryStore {
             // TODO:
             // Can we confirm that the rcsb.org servers have every id as a cif file?
             // If so, then we don't need to do this second try and we can always use .cif.
-            actualUrl = `https://files.rcsb.org/download/${pdbID}.cif`;
+            actualUrl = `https://files.rcsb.org/download/${pdbID}-assembly1.cif`;
         }
         return fetch(actualUrl)
             .then((response) => {
@@ -230,7 +230,7 @@ class GeometryStore {
                     return response.text();
                 } else if (pdbID) {
                     // try again as pdb
-                    actualUrl = `https://files.rcsb.org/download/${pdbID}.pdb`;
+                    actualUrl = `https://files.rcsb.org/download/${pdbID}.pdb1`;
                     return fetch(actualUrl).then((response) => {
                         if (!response.ok) {
                             // error will be caught by the function that calls this

--- a/src/visGeometry/PDBModel.ts
+++ b/src/visGeometry/PDBModel.ts
@@ -2,7 +2,6 @@ import "regenerator-runtime/runtime";
 
 import * as Comlink from "comlink";
 import parsePdb from "parse-pdb";
-import { getObject } from "./cifparser";
 import {
     Box3,
     BufferGeometry,
@@ -12,6 +11,7 @@ import {
 } from "three";
 
 import { KMeansWorkerType } from "./KMeansWorker";
+import { getObject } from "./cifparser";
 
 import KMeans from "./rendering/KMeans3d";
 import TaskQueue from "../simularium/TaskQueue";

--- a/src/visGeometry/PDBModel.ts
+++ b/src/visGeometry/PDBModel.ts
@@ -2,7 +2,6 @@ import "regenerator-runtime/runtime";
 
 import * as Comlink from "comlink";
 import parsePdb from "parse-pdb";
-import parseMmcif from "parse-mmcif";
 import { getObject } from "./cifparser";
 import {
     Box3,
@@ -119,10 +118,18 @@ class PDBModel {
     }
 
     private parseCIFData(data: string): void {
-        const parsedpdb = getObject(data) as PDBType;
+        interface AtomSite {
+            ["Cartn_x"]: number;
+            ["Cartn_y"]: number;
+            ["Cartn_z"]: number;
+        }
+        const parsedpdb: Record<string, unknown> = getObject(data);
         for (const obj in parsedpdb) {
             const mypdb = parsedpdb[obj];
-            if (mypdb._atom_site.length > 0) {
+            const atomSites = (mypdb as Record<string, unknown>)[
+                "_atom_site"
+            ] as AtomSite[];
+            if (atomSites.length > 0) {
                 this.pdb = {
                     atoms: [] as PDBAtom[],
                     seqRes: [],
@@ -130,11 +137,11 @@ class PDBModel {
                     chains: new Map(),
                 };
                 this.pdb.atoms = [];
-                for (let i = 0; i < mypdb._atom_site.length; ++i) {
+                for (let i = 0; i < atomSites.length; ++i) {
                     this.pdb?.atoms.push({
-                        x: mypdb._atom_site[i].Cartn_x,
-                        y: mypdb._atom_site[i].Cartn_y,
-                        z: mypdb._atom_site[i].Cartn_z,
+                        x: atomSites[i].Cartn_x,
+                        y: atomSites[i].Cartn_y,
+                        z: atomSites[i].Cartn_z,
                     });
                 }
                 this.fixupCoordinates();

--- a/src/visGeometry/cifparser.ts
+++ b/src/visGeometry/cifparser.ts
@@ -3,17 +3,17 @@
  * file informations.
  * @param {String} str - file contents
  */
-function getObject(str) {
+function getObject(str: string): Record<string, unknown> {
     //DELETE COMMENTS AND VOID
-    var fileArray = str
+    let fileArray = str
         .split("\n")
         .map((str) => str.trim())
         .filter((v) => v != "")
         .filter((v) => !v.startsWith("#"));
 
     //MERGE SEMICOLON LINES IN A UNIQUE ONE
-    var semicolon = false;
-    var sentence = "";
+    let semicolon = false;
+    let sentence = "";
 
     for (let index = 0; index < fileArray.length; index++) {
         if (fileArray[index].startsWith(";") && semicolon === false) {
@@ -36,17 +36,17 @@ function getObject(str) {
 
     fileArray = fileArray.filter((v) => v != "");
 
-    var fileObj = {};
+    const fileObj = {};
 
-    var datablockObj = {};
-    var firstBlock = true;
+    let datablockObj: Record<string, unknown> = {};
+    let firstBlock = true;
 
-    var isLoop = false;
-    var dataname = "";
-    var precArray = new Array();
+    let isLoop = false;
+    let dataname = "";
+    let precArray: string[] = [];
 
     //THIS FOREACH DIVIDES THE SINGLE BLOCKS AND ELABORATE THEM ONE AFTER ONE
-    fileArray.forEach((line) => {
+    fileArray.forEach((line: string) => {
         line = line.trim();
 
         if (line.startsWith("data_") && firstBlock) {
@@ -54,7 +54,7 @@ function getObject(str) {
             datablockObj["datablock"] = line.split("data_").join("");
             firstBlock = false;
         } else if (line.startsWith("data_") && !firstBlock) {
-            fileObj[datablockObj.datablock] = datablockObj;
+            fileObj[datablockObj.datablock as string] = datablockObj;
             datablockObj = {};
             datablockObj["datablock"] = line.split("data_").join("");
         } else {
@@ -67,13 +67,13 @@ function getObject(str) {
                         ...datablockObj,
                         ...elaborate(precArray, isLoop),
                     };
-                precArray = new Array();
+                precArray = [];
                 isLoop = true;
             } else if (dataname === "" && line.startsWith("_")) {
                 //NEW DATANAME IN LOOP OR FIRST DATANAME
 
                 dataname = line.split(".")[0];
-                precArray = new Array();
+                precArray = [];
                 precArray.push(line);
             } else if (
                 dataname !== "" &&
@@ -87,7 +87,7 @@ function getObject(str) {
                     ...datablockObj,
                     ...elaborate(precArray, isLoop),
                 };
-                precArray = new Array();
+                precArray = [];
                 precArray.push(line);
                 isLoop = false;
             } else {
@@ -98,7 +98,7 @@ function getObject(str) {
         }
     });
 
-    fileObj[datablockObj.datablock] = datablockObj;
+    fileObj[datablockObj.datablock as string] = datablockObj;
 
     return fileObj;
 }
@@ -109,17 +109,17 @@ function getObject(str) {
  * @param {boolean} isLoop - is it a loop block?
  */
 function elaborate(dataArray, isLoop) {
-    var valueArray = new Array();
-    var nameArray = new Array();
+    const valueArray: string[] = [];
+    const nameArray: string[] = [];
 
-    var dataName = "";
+    let dataName = "";
 
-    var JSONObj = {};
+    const jsonObj = {};
 
     if (isLoop) {
         //BLOCK IS LOOP
 
-        var contArray = new Array();
+        const contArray: Record<string, unknown>[] = [];
 
         dataArray.forEach((line) => {
             line = line.trim();
@@ -131,9 +131,9 @@ function elaborate(dataArray, isLoop) {
             } else {
                 //VALUES LINES
 
-                var field = "";
-                var controlChar = " ";
-                var pushed = false;
+                let field = "";
+                let controlChar = " ";
+                let pushed = false;
 
                 for (let index = 0; index < line.length; index++) {
                     //SPLIT BY WHITE SPACES EXEPT BETWEEN "" AND ''. P.S. I HATE REGEX.
@@ -188,8 +188,8 @@ function elaborate(dataArray, isLoop) {
             }
         });
 
-        var i = 0;
-        var obj = {};
+        let i = 0;
+        let obj = {};
         for (let increment = 0; increment < valueArray.length; increment++) {
             if (i === nameArray.length) {
                 i = 0;
@@ -203,11 +203,11 @@ function elaborate(dataArray, isLoop) {
 
         contArray.push(obj);
 
-        JSONObj[dataName] = contArray;
+        jsonObj[dataName] = contArray;
     } else {
         //NOT LOOP DATA
 
-        var dataName = dataArray.join("").trim().split(".")[0];
+        const dataName: string = dataArray.join("").trim().split(".")[0];
 
         dataArray = dataArray
             .join(" ")
@@ -215,20 +215,20 @@ function elaborate(dataArray, isLoop) {
             .split(dataName + ".")
             .filter((v) => v != "");
 
-        var subObj = {};
+        const subObj = {};
 
         dataArray.forEach((line) => {
             line = line.trim();
-            var id = line.split(" ")[0];
+            const id = line.split(" ")[0];
             line = line.replace(id, "").trim();
             line = line.split("'").join("");
             subObj[id] = line;
         });
 
-        JSONObj[dataName] = subObj;
+        jsonObj[dataName] = subObj;
     }
 
-    return JSONObj;
+    return jsonObj;
 }
 
 export { getObject };

--- a/src/visGeometry/cifparser.ts
+++ b/src/visGeometry/cifparser.ts
@@ -1,0 +1,234 @@
+/**
+ * This is the only method in the package. Given the file path it returns an Object containing the mmCIF
+ * file informations.
+ * @param {String} str - file contents
+ */
+function getObject(str) {
+    //DELETE COMMENTS AND VOID
+    var fileArray = str
+        .split("\n")
+        .map((str) => str.trim())
+        .filter((v) => v != "")
+        .filter((v) => !v.startsWith("#"));
+
+    //MERGE SEMICOLON LINES IN A UNIQUE ONE
+    var semicolon = false;
+    var sentence = "";
+
+    for (let index = 0; index < fileArray.length; index++) {
+        if (fileArray[index].startsWith(";") && semicolon === false) {
+            semicolon = true;
+            fileArray[index] = fileArray[index].substring(
+                1,
+                fileArray[index].length
+            );
+            sentence = sentence + fileArray[index];
+            fileArray[index] = "";
+        } else if (fileArray[index].startsWith(";") && semicolon === true) {
+            semicolon = false;
+            fileArray[index] = sentence;
+            sentence = "";
+        } else if (semicolon === true) {
+            sentence = sentence + fileArray[index];
+            fileArray[index] = "";
+        }
+    }
+
+    fileArray = fileArray.filter((v) => v != "");
+
+    var fileObj = {};
+
+    var datablockObj = {};
+    var firstBlock = true;
+
+    var isLoop = false;
+    var dataname = "";
+    var precArray = new Array();
+
+    //THIS FOREACH DIVIDES THE SINGLE BLOCKS AND ELABORATE THEM ONE AFTER ONE
+    fileArray.forEach((line) => {
+        line = line.trim();
+
+        if (line.startsWith("data_") && firstBlock) {
+            //IF THERE ARE MULTIPLE DATABLOCKS
+            datablockObj["datablock"] = line.split("data_").join("");
+            firstBlock = false;
+        } else if (line.startsWith("data_") && !firstBlock) {
+            fileObj[datablockObj.datablock] = datablockObj;
+            datablockObj = {};
+            datablockObj["datablock"] = line.split("data_").join("");
+        } else {
+            if (line === "loop_") {
+                //LOOP START
+
+                dataname = "";
+                if (precArray.length > 0)
+                    datablockObj = {
+                        ...datablockObj,
+                        ...elaborate(precArray, isLoop),
+                    };
+                precArray = new Array();
+                isLoop = true;
+            } else if (dataname === "" && line.startsWith("_")) {
+                //NEW DATANAME IN LOOP OR FIRST DATANAME
+
+                dataname = line.split(".")[0];
+                precArray = new Array();
+                precArray.push(line);
+            } else if (
+                dataname !== "" &&
+                dataname !== line.split(".")[0] &&
+                line.startsWith("_")
+            ) {
+                //NEW DATANAME NO LOOP
+
+                dataname = line.split(".")[0];
+                datablockObj = {
+                    ...datablockObj,
+                    ...elaborate(precArray, isLoop),
+                };
+                precArray = new Array();
+                precArray.push(line);
+                isLoop = false;
+            } else {
+                //INSIDE DATANAME
+
+                precArray.push(line);
+            }
+        }
+    });
+
+    fileObj[datablockObj.datablock] = datablockObj;
+
+    return fileObj;
+}
+
+/**
+ * This function elaborate the single block.
+ * @param {String[]} dataArray - the various lines
+ * @param {boolean} isLoop - is it a loop block?
+ */
+function elaborate(dataArray, isLoop) {
+    var valueArray = new Array();
+    var nameArray = new Array();
+
+    var dataName = "";
+
+    var JSONObj = {};
+
+    if (isLoop) {
+        //BLOCK IS LOOP
+
+        var contArray = new Array();
+
+        dataArray.forEach((line) => {
+            line = line.trim();
+
+            if (line.startsWith("_")) {
+                //DATANAME LINE
+                dataName = line.split(".")[0];
+                nameArray.push(line.split(".")[1]);
+            } else {
+                //VALUES LINES
+
+                var field = "";
+                var controlChar = " ";
+                var pushed = false;
+
+                for (let index = 0; index < line.length; index++) {
+                    //SPLIT BY WHITE SPACES EXEPT BETWEEN "" AND ''. P.S. I HATE REGEX.
+
+                    if (controlChar === " " && line.charAt(index) === "'") {
+                        // OPEN '
+
+                        controlChar = "'";
+                        pushed = false;
+                    } else if (
+                        controlChar === " " &&
+                        line.charAt(index) === '"'
+                    ) {
+                        // OpEN "
+
+                        controlChar = '"';
+                        pushed = false;
+                    } else if (
+                        controlChar === " " &&
+                        line.charAt(index) === " "
+                    ) {
+                        if (field.trim() !== "") valueArray.push(field);
+                        field = "";
+                        pushed = true;
+                    } else if (
+                        controlChar === "'" &&
+                        line.charAt(index) === "'"
+                    ) {
+                        // CLOSE '
+
+                        valueArray.push(field);
+                        field = "";
+                        controlChar = " ";
+                        pushed = true;
+                    } else if (
+                        controlChar === '"' &&
+                        line.charAt(index) === '"'
+                    ) {
+                        // CLOSE "
+
+                        valueArray.push(field);
+                        field = "";
+                        controlChar = " ";
+                        pushed = true;
+                    } else {
+                        field = field + line.charAt(index);
+                        pushed = false;
+                    }
+                }
+
+                if (!pushed) valueArray.push(field);
+            }
+        });
+
+        var i = 0;
+        var obj = {};
+        for (let increment = 0; increment < valueArray.length; increment++) {
+            if (i === nameArray.length) {
+                i = 0;
+                contArray.push(obj);
+                obj = {};
+            }
+
+            obj[nameArray[i]] = valueArray[increment];
+            i++;
+        }
+
+        contArray.push(obj);
+
+        JSONObj[dataName] = contArray;
+    } else {
+        //NOT LOOP DATA
+
+        var dataName = dataArray.join("").trim().split(".")[0];
+
+        dataArray = dataArray
+            .join(" ")
+            .trim()
+            .split(dataName + ".")
+            .filter((v) => v != "");
+
+        var subObj = {};
+
+        dataArray.forEach((line) => {
+            line = line.trim();
+            var id = line.split(" ")[0];
+            line = line.replace(id, "").trim();
+            line = line.split("'").join("");
+            subObj[id] = line;
+        });
+
+        JSONObj[dataName] = subObj;
+    }
+
+    return JSONObj;
+}
+
+export { getObject };

--- a/src/visGeometry/cifparser.ts
+++ b/src/visGeometry/cifparser.ts
@@ -98,6 +98,14 @@ function getObject(str: string): Record<string, unknown> {
         }
     });
 
+    // handle last block
+    if (precArray.length > 0) {
+        datablockObj = {
+            ...datablockObj,
+            ...elaborate(precArray, isLoop),
+        };
+    }
+
     fileObj[datablockObj.datablock as string] = datablockObj;
 
     return fileObj;


### PR DESCRIPTION
Problem
=======
some mmCIF files were not showing any atoms

Solution
========
find another cif parser online, incorporate it and convert it to typescript, and fix a bug in its code.  Replaces the previous cif parser.

We are still using a naive loading approach which simply uses one of each `_atom_site` in the file.   It is unknown whether this parser works with all cif files that the previous parser worked with.   However, it will be maintainable and fixable by us now - and we can address any issues as they come up.

I also added a simple "SinglePdbSimulator" which can be used to view any protein from the pdb!
