### PR TITLE
increase number of pdb atoms for levels of detail

### DIFF
--- a/src/visGeometry/PDBModel.ts
+++ b/src/visGeometry/PDBModel.ts
@@ -10,7 +10,7 @@ import {
     Vector3,
 } from "three";
 
-import { KMeansWorkerType } from "./KMeansWorker";
+import type { KMeansWorkerType } from "./KMeansWorker";
 import { getObject } from "./cifparser";
 
 import KMeans from "./rendering/KMeans3d";
@@ -296,9 +296,9 @@ class PDBModel {
         // levels of detail go from most detailed to least
         this.lodSizes = [
             n,
-            Math.max(Math.floor(n / 8), 1),
-            Math.max(Math.floor(n / 32), 1),
-            Math.max(Math.floor(n / 128), 1),
+            Math.max(Math.floor(n / 4), 1),
+            Math.max(Math.floor(n / 16), 1),
+            Math.max(Math.floor(n / 64), 1),
         ];
 
         // select random points for the initial quick LOD guess.

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -802,7 +802,7 @@ class VisGeometry {
                         visAgent.agentData.instanceId,
                         visAgent.signedTypeId(),
                         // a scale value for LODs
-                        (index + 1) * 0.25
+                        0.25 + index * 0.25
                     );
                     break;
                 }

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -235,7 +235,7 @@ class VisGeometry {
         this.currentSceneAgents = [];
         this.colorsData = new Float32Array(0);
         this.lodBias = 0;
-        this.lodDistanceStops = [40, 100, 150, Number.MAX_VALUE];
+        this.lodDistanceStops = [100, 200, 400, Number.MAX_VALUE];
         this.agentsWithPdbsToDraw = [];
         this.agentPdbsToDraw = [];
 
@@ -359,18 +359,16 @@ class VisGeometry {
 
         const settings = {
             lodBias: this.lodBias,
+            lod0: this.lodDistanceStops[0],
+            lod1: this.lodDistanceStops[1],
+            lod2: this.lodDistanceStops[2],
             bgcolor: {
                 r: this.backgroundColor.r * 255,
                 g: this.backgroundColor.g * 255,
                 b: this.backgroundColor.b * 255,
             },
         };
-        this.gui
-            .addInput(settings, "lodBias", { min: 0, max: 4, step: 1 })
-            .on("change", (event) => {
-                this.lodBias = event.value;
-                this.updateScene(this.currentSceneAgents);
-            });
+
         this.gui.addInput(settings, "bgcolor").on("change", (event) => {
             this.setBackgroundColor([
                 event.value.r / 255.0,
@@ -388,6 +386,25 @@ class VisGeometry {
             anchor.click();
         });
         this.gui.addSeparator();
+        const lodFolder = this.gui.addFolder({ title: "LoD", expanded: false });
+        lodFolder
+            .addInput(settings, "lodBias", { min: 0, max: 4, step: 1 })
+            .on("change", (event) => {
+                this.lodBias = event.value;
+                this.updateScene(this.currentSceneAgents);
+            });
+        lodFolder.addInput(settings, "lod0").on("change", (event) => {
+            this.lodDistanceStops[0] = event.value;
+            this.updateScene(this.currentSceneAgents);
+        });
+        lodFolder.addInput(settings, "lod1").on("change", (event) => {
+            this.lodDistanceStops[1] = event.value;
+            this.updateScene(this.currentSceneAgents);
+        });
+        lodFolder.addInput(settings, "lod2").on("change", (event) => {
+            this.lodDistanceStops[2] = event.value;
+            this.updateScene(this.currentSceneAgents);
+        });
         this.renderer.setupGui(this.gui);
     }
 

--- a/src/visGeometry/rendering/PDBGBufferShaders.ts
+++ b/src/visGeometry/rendering/PDBGBufferShaders.ts
@@ -87,7 +87,9 @@ layout(location = 2) out vec4 gPos;
 
         // uncomment the following line to test LOD.  IN_radius is a measure of lod.
         //gAgentInfo = vec4(IN_radius*4.0, IN_instanceAndTypeId.x, fragViewPos.z, fragPosDepth);
+
         gAgentInfo = vec4(IN_instanceAndTypeId.y, IN_instanceAndTypeId.x, fragViewPos.z, fragPosDepth);
+        
         gNormal = vec4(normal * 0.5 + 0.5, 1.0);
         gPos = vec4(fragViewPos.x, fragViewPos.y, fragViewPos.z, 1.0);
     }


### PR DESCRIPTION
Problem
=======
A couple of pdb molecules have a lower density of atoms, making them look significantly worse at low LOD.

Solution
========

Adjust the global settings for how much decimation we do.  Also adjust distance thresholds to increase amount of detail.

There are several parameters we can tweak to control this.  This is one of the very simplest changes.  We could also clamp numbers of atoms (say, LOD 1 should be 1/4 the number of atoms but can have no more than X atoms and no less than Y atoms).  Furthermore, we could have this depend on average density (number of atoms per bounding box volume).   The distance values where the LODs change is also very global and hardcoded and doesn't change with scene dimensions.

