### PR TITLE
Add first key to path in smoldyn form

### DIFF
--- a/examples/ConversionForm/index.tsx
+++ b/examples/ConversionForm/index.tsx
@@ -93,7 +93,7 @@ class InputForm extends React.Component<InputFormProps> {
                                 templateData={templateData}
                                 parameter={parameter}
                                 dataType={dataType}
-                                path={[]}
+                                path={[key]}
                             />
                         );
                     }


### PR DESCRIPTION
Problem
=======
I noticed that when submitting a smoldyn form, both time units and spatial units were both being represented as simply `name` and `magnitude` fields in the object that is sent to the lambda function. This meant that if the user put in both time units and spatial units, only one of them would appear in the final object and get processed.

Solution
========
With this change, the `name` and `magnitude` fields will be nested under either `time_units` or `spatial_units`, so we can process both sections.
## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* I added the top level key to the path used when building out all the input fields based on the json config. This allows the desired nesting to occur so that both names and magnitudes for time units and spatial units will be saved properly.
* This nesting does slightly change the paths for some of the other fields, which will be addressed in my forthcoming smoldyn simularium lambda PR
