### PR TITLE
Fix/init canvas size

### DIFF
--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -637,6 +637,8 @@ class Viewport extends React.Component<
                     }}
                     ref={this.vdomRef}
                     tabIndex={0}
+                    data-height={height}
+                    data-width={width}
                 >
                     {showCameraControls && this.renderViewControls()}
                 </div>

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -762,7 +762,7 @@ class VisGeometry {
         parent.appendChild(this.threejsrenderer.domElement);
         this.setUpControls(this.threejsrenderer.domElement);
 
-        this.resize(parent.scrollWidth, parent.scrollHeight);
+        this.resize(Number(parent.dataset.width), Number(parent.dataset.width));
 
         this.threejsrenderer.setClearColor(this.backgroundColor, 1.0);
         this.threejsrenderer.clear();

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -762,7 +762,10 @@ class VisGeometry {
         parent.appendChild(this.threejsrenderer.domElement);
         this.setUpControls(this.threejsrenderer.domElement);
 
-        this.resize(Number(parent.dataset.width), Number(parent.dataset.width));
+        this.resize(
+            Number(parent.dataset.width),
+            Number(parent.dataset.height)
+        );
 
         this.threejsrenderer.setClearColor(this.backgroundColor, 1.0);
         this.threejsrenderer.clear();


### PR DESCRIPTION
Problem
=======
When trying to initialize the viewer in a jupyter notebook, the parent ele had no scrollHeight/Width, so the viewer wasn't being size correctly. We could get it to size correctly by calling `VisGeometry.resize` after mount, but it would be better to have it just have the correct height to begin with. 

Solution
========
Use html data instead of trying to grab the style in javascript. The height and width are computed in the DOM, while the data attributes are constants so we don't have to worry about wether the ele has mounted yet. 
with @toloudis 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. npm start
2. the viewer should look normal, and resize normally. 
