### PR TITLE
Bug fix: Default to secureConnection = true if it not defined

### DIFF
--- a/src/simularium/ISimulariumFile.ts
+++ b/src/simularium/ISimulariumFile.ts
@@ -1,9 +1,4 @@
-import type {
-    Plot,
-    TrajectoryFileInfo,
-    VisDataFrame,
-    VisDataMessage,
-} from "./types";
+import type { Plot, TrajectoryFileInfo, VisDataFrame } from "./types";
 
 export interface ISimulariumFile {
     getTrajectoryFileInfo(): TrajectoryFileInfo;

--- a/src/simularium/JsonFileReader.ts
+++ b/src/simularium/JsonFileReader.ts
@@ -4,7 +4,6 @@ import type {
     SimulariumFileFormat,
     TrajectoryFileInfo,
     VisDataFrame,
-    VisDataMessage,
 } from "./types";
 import { FrontEndError } from "./FrontEndError";
 import { compareTimes } from "../util";

--- a/src/simularium/WebsocketClient.ts
+++ b/src/simularium/WebsocketClient.ts
@@ -93,7 +93,9 @@ export class WebsocketClient {
         this.serverIp = opts && opts.serverIp ? opts.serverIp : "localhost";
         this.serverPort = opts && opts.serverPort ? opts.serverPort : 9002;
         this.secureConnection =
-            opts && opts.secureConnection ? opts.secureConnection : false;
+            opts && opts.secureConnection !== undefined
+                ? opts.secureConnection
+                : true;
         this.connectionTimeWaited = 0;
         this.connectionRetries = 0;
         this.handleError =


### PR DESCRIPTION
Problem
=======
With the new release of the simularium viewer, @interim17 ran into a bug with how the simularium viewer works with the simularium website in dev mode. Dev mode of the simularium website was failing to communicate with the backend server because it was trying to reach the URL **ws**://staging-node1-agentviz-backend.cellexplore.net instead of **wss**://staging-node1-agentviz-backend.cellexplore.net

With [this PR](https://github.com/simularium/simularium-viewer/pull/302), I added `useOctopus` and `secureConnection` to `netConnectionSettings`, but I forgot that there are others using this, not just the example viewer. Fortunately, if `useOctopus` isn't provided, it defaults to false, which matches with the behavior that existed prior to that PR. However, `secureConnection` also defaults to false when not provided, which results in `ws` being used as the websocket protocol instead of `wss`, which was the default behavior before. This PR changes `secureConnection` to default to true if not provided, maintaining the previous behavior.

TLDR:
`secureConnection: true` -> `wss://`
`secureConnection: false` -> `wss://`
NEW: `secureConnection: undefined` -> `wss://`
