### PR TITLE
Fix `VisGeometry` constructor overwriting properties it initializes

### DIFF
--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -118,9 +118,6 @@ class Viewport extends React.Component<
 
         this.visGeometry = new VisGeometry(loggerLevel);
         this.props.simulariumController.visData.clearCache();
-        // TODO this is called in the `VisGeometry` constructor. Why is it called
-        //   again here? Removing it generates arcane WebGL warnings - why?
-        this.visGeometry.setupScene();
         this.visGeometry.createMaterials(props.agentColors);
         this.vdomRef = React.createRef();
         this.lastRenderTime = Date.now();

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -197,8 +197,6 @@ class VisGeometry {
 
         this.fibers = new InstancedFiberGroup();
 
-        this.setupScene();
-
         this.legacyRenderer = new LegacyRenderer();
         this.renderer = new SimulariumRenderer();
 
@@ -206,8 +204,69 @@ class VisGeometry {
         this.pathEndColor = this.backgroundColor.clone();
         this.renderer.setBackgroundColor(this.backgroundColor);
 
+        // Set up scene
+
+        this.scene = new Scene();
+        this.lightsGroup = new Group();
+        this.lightsGroup.name = "lights";
+        this.scene.add(this.lightsGroup);
+        this.agentPathGroup = new Group();
+        this.agentPathGroup.name = "agent paths";
+        this.scene.add(this.agentPathGroup);
+        this.instancedMeshGroup = new Group();
+        this.instancedMeshGroup.name = "instanced meshes for agents";
+        this.scene.add(this.instancedMeshGroup);
+
+        this.resetBounds(DEFAULT_VOLUME_DIMENSIONS);
+
+        this.dl = new DirectionalLight(0xffffff, 0.6);
+        this.dl.position.set(0, 0, 1);
+        this.lightsGroup.add(this.dl);
+
+        this.hemiLight = new HemisphereLight(0xffffff, 0x000000, 0.5);
+        this.hemiLight.color.setHSL(0.095, 1, 0.75);
+        this.hemiLight.groundColor.setHSL(0.6, 1, 0.6);
+        this.hemiLight.position.set(0, 1, 0);
+        this.lightsGroup.add(this.hemiLight);
+
+        // Set up renderer
+
+        if (WEBGL.isWebGL2Available() === false) {
+            this.renderStyle = RenderStyle.WEBGL1_FALLBACK;
+            this.supportsWebGL2Rendering = false;
+            this.threejsrenderer = new WebGLRenderer({
+                premultipliedAlpha: false,
+            });
+        } else {
+            this.renderStyle = RenderStyle.WEBGL2_PREFERRED;
+            this.supportsWebGL2Rendering = true;
+            const canvas = document.createElement("canvas");
+            const context: WebGLRenderingContext = canvas.getContext("webgl2", {
+                alpha: false,
+            }) as WebGLRenderingContext;
+
+            const rendererParams: WebGLRendererParameters = {
+                canvas: canvas,
+                context: context,
+                premultipliedAlpha: false,
+            };
+            this.threejsrenderer = new WebGLRenderer(rendererParams);
+        }
+
+        // set this up after the renderStyle has been set.
+        this.constructInstancedFibers();
+
+        this.threejsrenderer.setSize(
+            CANVAS_INITIAL_WIDTH,
+            CANVAS_INITIAL_HEIGHT
+        ); // expected to change when reparented
+        this.threejsrenderer.setClearColor(this.backgroundColor, 1);
+        this.threejsrenderer.clear();
+
         this.mlogger = jsLogger.get("visgeometry");
         this.mlogger.setLevel(loggerLevel);
+
+        // Set up cameras
 
         this.cameraDefault = cloneDeep(DEFAULT_CAMERA_SPEC);
         const aspect = CANVAS_INITIAL_WIDTH / CANVAS_INITIAL_HEIGHT;
@@ -734,66 +793,6 @@ class VisGeometry {
         // Orthographic camera limits - based on zoom level
         this.controls.maxZoom = MAX_ZOOM;
         this.controls.minZoom = MIN_ZOOM;
-    }
-
-    /**
-     *   Setup ThreeJS Scene
-     */
-    public setupScene(): void {
-        this.scene = new Scene();
-        this.lightsGroup = new Group();
-        this.lightsGroup.name = "lights";
-        this.scene.add(this.lightsGroup);
-        this.agentPathGroup = new Group();
-        this.agentPathGroup.name = "agent paths";
-        this.scene.add(this.agentPathGroup);
-        this.instancedMeshGroup = new Group();
-        this.instancedMeshGroup.name = "instanced meshes for agents";
-        this.scene.add(this.instancedMeshGroup);
-
-        this.resetBounds(DEFAULT_VOLUME_DIMENSIONS);
-
-        this.dl = new DirectionalLight(0xffffff, 0.6);
-        this.dl.position.set(0, 0, 1);
-        this.lightsGroup.add(this.dl);
-
-        this.hemiLight = new HemisphereLight(0xffffff, 0x000000, 0.5);
-        this.hemiLight.color.setHSL(0.095, 1, 0.75);
-        this.hemiLight.groundColor.setHSL(0.6, 1, 0.6);
-        this.hemiLight.position.set(0, 1, 0);
-        this.lightsGroup.add(this.hemiLight);
-
-        if (WEBGL.isWebGL2Available() === false) {
-            this.renderStyle = RenderStyle.WEBGL1_FALLBACK;
-            this.supportsWebGL2Rendering = false;
-            this.threejsrenderer = new WebGLRenderer({
-                premultipliedAlpha: false,
-            });
-        } else {
-            this.renderStyle = RenderStyle.WEBGL2_PREFERRED;
-            this.supportsWebGL2Rendering = true;
-            const canvas = document.createElement("canvas");
-            const context: WebGLRenderingContext = canvas.getContext("webgl2", {
-                alpha: false,
-            }) as WebGLRenderingContext;
-
-            const rendererParams: WebGLRendererParameters = {
-                canvas: canvas,
-                context: context,
-                premultipliedAlpha: false,
-            };
-            this.threejsrenderer = new WebGLRenderer(rendererParams);
-        }
-
-        // set this up after the renderStyle has been set.
-        this.constructInstancedFibers();
-
-        this.threejsrenderer.setSize(
-            CANVAS_INITIAL_WIDTH,
-            CANVAS_INITIAL_HEIGHT
-        ); // expected to change when reparented
-        this.threejsrenderer.setClearColor(this.backgroundColor, 1);
-        this.threejsrenderer.clear();
     }
 
     public resize(width: number, height: number): void {

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -201,6 +201,12 @@ class VisGeometry {
         this.lightsGroup = new Group();
         this.agentPathGroup = new Group();
         this.instancedMeshGroup = new Group();
+        this.threejsrenderer = new WebGLRenderer();
+        this.dl = new DirectionalLight();
+        this.boundingBox = new Box3();
+        this.boundingBoxMesh = new Box3Helper(this.boundingBox);
+        this.tickMarksMesh = new LineSegments();
+        this.hemiLight = new HemisphereLight();
 
         this.setupScene();
 
@@ -231,22 +237,10 @@ class VisGeometry {
         this.camera.position.z = DEFAULT_CAMERA_Z_POSITION;
         this.initCameraPosition = this.camera.position.clone();
 
-        this.dl = new DirectionalLight(0xffffff, 0.6);
-        this.hemiLight = new HemisphereLight(0xffffff, 0x000000, 0.5);
-        this.threejsrenderer = new WebGLRenderer({ premultipliedAlpha: false });
-        this.controls = this.setupControls(this.threejsrenderer.domElement);
+        this.controls = this.setupControls();
         this.focusMode = true;
 
-        this.boundingBox = new Box3(
-            new Vector3(0, 0, 0),
-            new Vector3(100, 100, 100)
-        );
-        this.boundingBoxMesh = new Box3Helper(
-            this.boundingBox,
-            BOUNDING_BOX_COLOR
-        );
         this.tickIntervalLength = 0;
-        this.tickMarksMesh = new LineSegments();
         this.boxNearZ = 0;
         this.boxFarZ = 100;
         this.currentSceneAgents = [];
@@ -256,7 +250,7 @@ class VisGeometry {
         this.agentsWithPdbsToDraw = [];
         this.agentPdbsToDraw = [];
 
-        this.onError = (/*errorMessage*/) => noop();
+        this.onError = noop;
     }
 
     public setOnErrorCallBack(onError: (error: FrontEndError) => void): void {
@@ -722,8 +716,11 @@ class VisGeometry {
         this.updateScene(this.currentSceneAgents);
     }
 
-    private setupControls(element: HTMLElement): OrbitControls {
-        this.controls = new OrbitControls(this.camera, element);
+    private setupControls(): OrbitControls {
+        this.controls = new OrbitControls(
+            this.camera,
+            this.threejsrenderer.domElement
+        );
         this.controls.addEventListener("change", () => {
             if (this.gui) {
                 this.gui.refresh();
@@ -863,7 +860,7 @@ class VisGeometry {
         }
 
         parent.appendChild(this.threejsrenderer.domElement);
-        this.setupControls(this.threejsrenderer.domElement);
+        this.setupControls();
 
         this.resize(
             Number(parent.dataset.width),

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -121,16 +121,16 @@ class VisGeometry {
     public agentPaths: Map<number, AgentPath>;
     public mlogger: ILogger;
     // this is the threejs object that issues all the webgl calls
-    public threejsrenderer!: WebGLRenderer;
-    public scene!: Scene;
+    public threejsrenderer: WebGLRenderer;
+    public scene: Scene;
 
     public perspectiveCamera: PerspectiveCamera;
     public orthographicCamera: OrthographicCamera;
     public camera: PerspectiveCamera | OrthographicCamera;
     public controls: OrbitControls;
 
-    public dl!: DirectionalLight;
-    public hemiLight!: HemisphereLight;
+    public dl: DirectionalLight;
+    public hemiLight: HemisphereLight;
     public boundingBox!: Box3;
     public boundingBoxMesh!: Box3Helper;
     public tickMarksMesh!: LineSegments;
@@ -143,9 +143,9 @@ class VisGeometry {
     public legacyRenderer: LegacyRenderer;
     public currentSceneAgents: AgentData[];
     public colorsData: Float32Array;
-    public lightsGroup!: Group;
-    public agentPathGroup!: Group;
-    public instancedMeshGroup!: Group;
+    public lightsGroup: Group;
+    public agentPathGroup: Group;
+    public instancedMeshGroup: Group;
     public idColorMapping: Map<number, number>;
     private isIdColorMappingSet: boolean;
     private supportsWebGL2Rendering: boolean;

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -121,31 +121,31 @@ class VisGeometry {
     public agentPaths: Map<number, AgentPath>;
     public mlogger: ILogger;
     // this is the threejs object that issues all the webgl calls
-    public threejsrenderer: WebGLRenderer;
-    public scene: Scene;
+    public threejsrenderer!: WebGLRenderer;
+    public scene!: Scene;
 
     public perspectiveCamera: PerspectiveCamera;
     public orthographicCamera: OrthographicCamera;
     public camera: PerspectiveCamera | OrthographicCamera;
     public controls: OrbitControls;
 
-    public dl: DirectionalLight;
-    public boundingBox: Box3;
-    public boundingBoxMesh: Box3Helper;
+    public dl!: DirectionalLight;
+    public hemiLight!: HemisphereLight;
+    public boundingBox!: Box3;
+    public boundingBoxMesh!: Box3Helper;
+    public tickMarksMesh!: LineSegments;
     public tickIntervalLength: number;
-    public tickMarksMesh: LineSegments;
     // front and back of transformed bounds in camera space
     private boxNearZ: number;
     private boxFarZ: number;
 
-    public hemiLight: HemisphereLight;
     public renderer: SimulariumRenderer;
     public legacyRenderer: LegacyRenderer;
     public currentSceneAgents: AgentData[];
     public colorsData: Float32Array;
-    public lightsGroup: Group;
-    public agentPathGroup: Group;
-    public instancedMeshGroup: Group;
+    public lightsGroup!: Group;
+    public agentPathGroup!: Group;
+    public instancedMeshGroup!: Group;
     public idColorMapping: Map<number, number>;
     private isIdColorMappingSet: boolean;
     private supportsWebGL2Rendering: boolean;
@@ -196,17 +196,6 @@ class VisGeometry {
         this.agentPaths = new Map<number, AgentPath>();
 
         this.fibers = new InstancedFiberGroup();
-
-        this.scene = new Scene();
-        this.lightsGroup = new Group();
-        this.agentPathGroup = new Group();
-        this.instancedMeshGroup = new Group();
-        this.threejsrenderer = new WebGLRenderer();
-        this.dl = new DirectionalLight();
-        this.boundingBox = new Box3();
-        this.boundingBoxMesh = new Box3Helper(this.boundingBox);
-        this.tickMarksMesh = new LineSegments();
-        this.hemiLight = new HemisphereLight();
 
         this.setupScene();
 


### PR DESCRIPTION
Problem
=======
This addresses [a comment](https://github.com/simularium/simularium-viewer/blob/main/src/viewport/index.tsx#L121) I left in #314: a new `VisGeometry` object must have its `setupScene` method called before it can be used, despite the fact that `setupScene` is already called once in its constructor.

Solution
========
After calling `setupScene` to properly initialize scene objects and place them in the scene graph, `VisGeometry`'s constructor turned out to be reinitializing many key objects (including lights, bounding box, and the renderer itself) without the same setup. Thus the `setupScene` call after construction was required to recreate these objects a third time with the correct configuration. I removed initializers for objects that are initialized in `setupScene` from the constructor and was able to remove the `setupScene` call after the constructor without issue.

This creates a bit of a problem for TypeScript: it wants to be sure that all non-optional declared properties of a class are given initial values in the constructor, and [is unwilling to check](https://www.typescriptlang.org/docs/handbook/2/classes.html#--strictpropertyinitialization) methods called by the constructor for initializations. There are a few possible solutions to this:

- *Give all properties initialized in the method definite assignment assertions (`!:`).* This effectively disables this check for a single property, and is what I ended up doing, though it comes at a cost of less rigorous checking.
- *Give all properties initialized in the method dummy initializers before the method is called.* This keeps the type system happier but adds redundant work to the code.
- *Delete `setupScene` and inline its code in the constructor.* It's not clear to me that a user of `VisGeometry` would ever have a use for a `VisGeometry` without a fully set up scene, or that anyone would want to call `setupScene` to reinitialize `VisGeometry`'s most essential properties rather than creating an entirely new instance. If they definitely would not want either option, `setupScene`'s code could just be moved into the constructor. This would make the constructor a bit bloated, but honestly not unusually so given `VisGeometry`'s size and complexity.
