### PR TITLE
Fix bug with responding to heartbeat ping

### DIFF
--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -149,7 +149,7 @@ export class RemoteSimulator implements ISimulator {
 
         this.webSocketClient.addJsonMessageHandler(
             NetMessageEnum.ID_HEARTBEAT_PING,
-            this.onHeartbeatPing
+            (msg) => this.onHeartbeatPing(msg)
         );
 
         this.webSocketClient.addJsonMessageHandler(


### PR DESCRIPTION
Problem
=======
Joe noticed that errors were showing up in the example viewer when a "ping" message was received from the simularium engine, and the viewer was failing to send a "pong" response. I didn't notice this before because it doesn't come up with Octopus.

I saw this a lot when I was digging in on on [this ticket](https://github.com/simularium/simularium-website/issues/421), and it was bothering me a lot so I dug in while I was there.

It's a tiny fix. Ugh. Still figuring out how to not shoot myself in the foot when I write JavaScript / TypeScript code, I suppose the only to improve is to keep practicing.
