### PR TITLE
Catch error that occurs in race condition

### DIFF
--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -489,14 +489,24 @@ class VisData {
                 this.netBuffer.byteLength
             );
 
-            const frames = VisData.parseBinary(tmp);
-            if (
-                frames.frameDataArray.length > 0 &&
-                frames.frameDataArray[0].frameNumber === 0
-            ) {
-                this.clearCache(); // new data has arrived
+            try {
+                const frames = VisData.parseBinary(tmp);
+                if (
+                    frames.frameDataArray.length > 0 &&
+                    frames.frameDataArray[0].frameNumber === 0
+                ) {
+                    this.clearCache(); // new data has arrived
+                }
+                this.addFramesToCache(frames);
+            } catch (err) {
+                // TODO: There are frequent errors due to a race condition that
+                // occurs when jumping to a new time if a partial frame is received
+                // after netBuffer is cleared. When binary messages are updated to
+                // include frame num for partial frames in their header, we can
+                // ensure that netBuffer is being combined with the matching frame,
+                // and this try/catch can be removed
+                console.log(err);
             }
-            this.addFramesToCache(frames);
 
             // Save remaining data for later processing
             const remainder = data.slice(eof + EOF_PHRASE.length);

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -501,10 +501,12 @@ class VisData {
             } catch (err) {
                 // TODO: There are frequent errors due to a race condition that
                 // occurs when jumping to a new time if a partial frame is received
-                // after netBuffer is cleared. When binary messages are updated to
-                // include frame num for partial frames in their header, we can
-                // ensure that netBuffer is being combined with the matching frame,
-                // and this try/catch can be removed
+                // after netBuffer is cleared. We don't want this to trigger a front
+                // end error, it's best to catch it here and just move on, as the
+                // issue should be contained to just one frame. When binary messages
+                // are updated to include frame num for partial frames in their header,
+                // we can ensure that netBuffer is being combined with the matching
+                // frame, and this try/catch can be removed
                 console.log(err);
             }
 


### PR DESCRIPTION
Problem
=======
As defined in the ticket, there is a bug where uncaught FrontEndErrors are getting thrown in `VisData.parseBinary()` sometimes when the user is jumping to a new simulation time on the time slider.

This is due to a race condition that can easily occur because of how we're communicating with the simularium-engine. In short, when a user jumps to a new time, we send a pause message to the simularium-engine, clear the cache and the variable where we're potentially holding a chunk of incomplete frame data, and then request frame data at the new time point from simularium-engine. However, sometimes the viewer receives a chunk of data from the old time that was sent by the engine before it received the pause request, and is received by the viewer after we had already cleared the variable holding the other piece of that frame data. 

[Link to ticket](https://github.com/simularium/simularium-website/issues/421)

Solution
========
We're not actually solving this problem right now. Rather than sticking a weird bandaid on it, we're going to address this in octopus in this [ticket](https://github.com/simularium/octopus/issues/39). In the meantime, we shouldn't flood the user with errors that they can't be doing anything about, so let's catch the error and just log it.

