### PR TITLE
bind setCameraType and this in controller

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -115,6 +115,7 @@ export default class SimulariumController {
         this.setFocusMode = this.setFocusMode.bind(this);
         this.convertAndLoadTrajectory =
             this.convertAndLoadTrajectory.bind(this);
+        this.setCameraType = this.setCameraType.bind(this);
     }
 
     private createSimulatorConnection(


### PR DESCRIPTION
Problem
=======
Trying to implement Orthographic Camera in simularium-website was yielding an error, "visGeometry is undefined", because setCameraType was being called without correct "this" binding. 


Solution
========
Binding setCameraType "this" in the controller makes the function callable from the website's camera controls.
Functionality in the example viewer is preserved.
* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
Seems like a simple fix, but let me know if there could be side effects I'm not anticipating?

Steps to Verify:
----------------
If you really want to verify you can, from the Viewer repo:
- create a dev build (npm run build, npm run copy-build)

Then from the Website repo:
- checkout feature/orthographic-ui
- npm i [PATH_TO_DEVBUILD] (if you have troubles you might need to delete node modules, package-lock, and clear node cache...)
- load a trajectory try to toggle camera mode

