### PR TITLE
Feature/set agent color

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -6,14 +6,14 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: "16.x"
 
       - name: Cache dependencies
  

--- a/examples/ColorPicker.tsx
+++ b/examples/ColorPicker.tsx
@@ -49,10 +49,10 @@ const ColorPicker = ({
                     tags: subAgent,
                 },
             ];
-            setColorSelectionInfo({
+            setColorSelectionInfo([{
                 agents: entry,
                 color: selectedColor,
-            });
+            }]);
         }
     };
 

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -87,8 +87,9 @@ interface ViewerState {
         data: ISimulariumFile | null;
     } | null;
     selectedColor: string;
+    customColor: string;
+    assignedColor: string;
     selectedAgent: string;
-    colorToAdd: string;
 }
 
 interface BaseType {
@@ -149,7 +150,7 @@ const initialState: ViewerState = {
     simulariumFile: null,
     selectedColor: "",
     selectedAgent: "",
-    colorToAdd: "",
+    customColor: "",
 };
 
 type FrontEndError = typeof FrontEndError;
@@ -627,18 +628,19 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     ...this.state.selectionStateInfo,
                     colorChangeAgents: entryArray,
                 },
+                assignedColor: this.state.selectedColor,
             });
         }
     };
 
     public receiveNewColorInput = (event) => {
         const value = event.target.value;
-        this.setState({ colorToAdd: value });
+        this.setState({ customColor: value });
     };
 
     public addColorToColorArray = (event) => {
         const hexColorCodeRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
-        const color = this.state.colorToAdd;
+        const color = this.state.customColor;
         if (hexColorCodeRegex.test(color)) {
             this.setState({
                 agentColors: [...this.state.agentColors, color] as string[],
@@ -941,7 +943,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                         showPaths={this.state.showPaths}
                         onError={this.onError}
                         backgroundColor={[0, 0, 0]}
-                        selectedColor={this.state.selectedColor}
+                        assignedColor={this.state.assignedColor}
                     />
                 </div>
             </div>

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -643,7 +643,6 @@ class Viewer extends React.Component<InputParams, ViewerState> {
             this.setState({
                 agentColors: [...this.state.agentColors, color] as string[],
             });
-            simulariumController.visGeometry.addColorToColorArray(color);
         } else {
             alert("Please enter a valid hex color code");
         }

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -90,6 +90,8 @@ interface ViewerState {
     customColor: string;
     assignedColor: string;
     selectedAgent: string;
+    subAgentNames: string[];
+    selectedSubAgent: string;
 }
 
 interface BaseType {
@@ -151,6 +153,8 @@ const initialState: ViewerState = {
     selectedColor: "",
     selectedAgent: "",
     customColor: "",
+    subAgentNames: [],
+    selectedSubAgent: "",
 };
 
 type FrontEndError = typeof FrontEndError;
@@ -606,6 +610,26 @@ class Viewer extends React.Component<InputParams, ViewerState> {
     public handleAgentSelection = (event) => {
         const value = event.target.value;
         this.setState({ selectedAgent: value });
+        const subAgents = this.getSubAgentsforAgent(value);
+        if (subAgents) {
+            this.setState({ subAgentNames: subAgents });
+        }
+    };
+
+    public handleSubAgentSelection = (event) => {
+        const value = event.target.value;
+        this.setState({ selectedSubAgent: value });
+    };
+
+    public getSubAgentsforAgent = (agentName: string) => {
+        const agent = this.state.uiDisplayData.find(
+            (element) => element.name === agentName
+        );
+        if (!agent) {
+            throw new Error("No agent found");
+            return;
+        }
+        return agent.displayStates.map((element) => element.id);
     };
 
     public assignColorToAgent = () => {
@@ -616,17 +640,16 @@ class Viewer extends React.Component<InputParams, ViewerState> {
             throw new Error("No color selected");
             return;
         } else {
-            // todo: handle tags
-            const entry: SelectionEntry = {
+            const subAgent: string[] = this.state.selectedSubAgent ? [this.state.selectedSubAgent] : [];
+            const entry: SelectionEntry[] = [{
                 name: this.state.selectedAgent,
-                tags: [],
-            };
-            const entryArray: SelectionEntry[] = [entry];
+                tags: subAgent,
+            }];
             this.setState({
                 ...this.state,
                 selectionStateInfo: {
                     ...this.state.selectionStateInfo,
-                    colorChangeAgents: entryArray,
+                    colorChangeAgents: entry,
                 },
                 assignedColor: this.state.selectedColor,
             });
@@ -684,15 +707,33 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     <option value="microtubules30_1.h5">MT 30</option>
                     <option value="endocytosis.simularium">Endocytosis</option>
                     <option value="pc4covid19.simularium">COVIDLUNG</option>
-                    <option value="nanoparticle_wrapping.simularium">Nanoparticle wrapping</option>
-                    <option value="smoldyn_min1.simularium">Smoldyn min1</option>
-                    <option value="smoldyn_spine.simularium">Smoldyn spine</option>
-                    <option value="medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.675.simularium">medyan 625</option>
-                    <option value="medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.0225.simularium">medyan 0225</option>
-                    <option value="springsalad_condensate_formation_Below_Ksp.simularium">springsalad below ksp</option>
-                    <option value="springsalad_condensate_formation_At_Ksp.simularium">springsalad at ksp</option>
-                    <option value="springsalad_condensate_formation_Above_Ksp.simularium">springsalad above ksp</option>
-                    <option value="blood-plasma-1.0.simularium">blood plasma</option>
+                    <option value="nanoparticle_wrapping.simularium">
+                        Nanoparticle wrapping
+                    </option>
+                    <option value="smoldyn_min1.simularium">
+                        Smoldyn min1
+                    </option>
+                    <option value="smoldyn_spine.simularium">
+                        Smoldyn spine
+                    </option>
+                    <option value="medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.675.simularium">
+                        medyan 625
+                    </option>
+                    <option value="medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.0225.simularium">
+                        medyan 0225
+                    </option>
+                    <option value="springsalad_condensate_formation_Below_Ksp.simularium">
+                        springsalad below ksp
+                    </option>
+                    <option value="springsalad_condensate_formation_At_Ksp.simularium">
+                        springsalad at ksp
+                    </option>
+                    <option value="springsalad_condensate_formation_Above_Ksp.simularium">
+                        springsalad above ksp
+                    </option>
+                    <option value="blood-plasma-1.0.simularium">
+                        blood plasma
+                    </option>
                     <option value="TEST_SINGLE_PDB">TEST SINGLE PDB</option>
                     <option value="TEST_PDB">TEST PDB</option>
                     <option value="TEST_FIBERS">TEST FIBERS</option>
@@ -855,7 +896,9 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 <br />
                 <button
                     onClick={() =>
-                        simulariumController.getMetrics(this.netConnectionSettings)
+                        simulariumController.getMetrics(
+                            this.netConnectionSettings
+                        )
                     }
                 >
                     Get available metrics
@@ -888,12 +931,25 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     Tick interval length:{" "}
                     {simulariumController.tickIntervalLength}
                 </span>
+                <br></br>
+                <span>Color change agent selection:</span>
                 <select
                     id="agentSelect"
                     onChange={this.handleAgentSelection}
                     defaultValue={this.state.selectedAgent}
                 >
                     {this.state.particleTypeNames.map((name) => (
+                        <option value={name}>{name}</option>
+                    ))}
+                </select>
+                {/* a select that takes a chosen agent and display tags aka subtypes */}
+                <span> Color change subagent selection:</span>
+                <select
+                    id="subAgentSelect"
+                    onChange={this.handleSubAgentSelection}
+                    defaultValue={this.state.selectedSubAgent}
+                >
+                    {this.state.subAgentNames.map((name) => (
                         <option value={name}>{name}</option>
                     ))}
                 </select>

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -932,23 +932,23 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     {simulariumController.tickIntervalLength}
                 </span>
                 <br></br>
-                <span>Color change agent selection:</span>
+                <span>Color change agent selections:</span>
                 <select
                     id="agentSelect"
                     onChange={this.handleAgentSelection}
-                    defaultValue={this.state.selectedAgent}
+                    defaultValue="Select Agent"
                 >
+                    <option value="Select Agent"> Select Agent</option>
                     {this.state.particleTypeNames.map((name) => (
                         <option value={name}>{name}</option>
                     ))}
                 </select>
-                {/* a select that takes a chosen agent and display tags aka subtypes */}
-                <span> Color change subagent selection:</span>
                 <select
                     id="subAgentSelect"
                     onChange={this.handleSubAgentSelection}
-                    defaultValue={this.state.selectedSubAgent}
+                    defaultValue="Select Sub-Agent"
                 >
+                    <option value="Select Sub-Agent"> Select Sub-Agent</option>
                     {this.state.subAgentNames.map((name) => (
                         <option value={name}>{name}</option>
                     ))}
@@ -959,6 +959,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     defaultValue={this.state.selectedColor}
                     style={{ backgroundColor: this.state.selectedColor }}
                 >
+                    <option value="Select Color"> Select Color</option>
                     {this.state.agentColors.map((name) => (
                         <option value={name}>{name}</option>
                     ))}

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -140,7 +140,7 @@ const initialState: ViewerState = {
     selectionStateInfo: {
         highlightedAgents: [],
         hiddenAgents: [],
-        colorChanges: { agents: [], color: "" },
+        colorChanges: [{ agents: [], color: "" }],
     },
     filePending: null,
     simulariumFile: null,

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -936,7 +936,6 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 <select
                     id="agentSelect"
                     onChange={this.handleAgentSelection}
-                    defaultValue="Select Agent"
                 >
                     <option value="Select Agent"> Select Agent</option>
                     {this.state.particleTypeNames.map((name) => (
@@ -946,7 +945,6 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 <select
                     id="subAgentSelect"
                     onChange={this.handleSubAgentSelection}
-                    defaultValue="Select Sub-Agent"
                 >
                     <option value="Select Sub-Agent"> Select Sub-Agent</option>
                     {this.state.subAgentNames.map((name) => (

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export type {
     SelectionStateInfo,
     UIDisplayData,
     VisDataFrame,
+    ColorChanges,
+    SelectionEntry,
 } from "./simularium";
 export type { ISimulariumFile } from "./simularium/ISimulariumFile";
 

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -25,7 +25,7 @@ export interface ColorChanges {
 export interface SelectionStateInfo {
     highlightedAgents: SelectionEntry[];
     hiddenAgents: SelectionEntry[];
-    colorChanges: ColorChanges;
+    colorChanges: ColorChanges[];
 }
 
 interface DisplayStateEntry {
@@ -277,6 +277,7 @@ class SelectionInterface {
     ): void {
         const newColor = convertColorNumberToString(color);
         const entry = this.entries[agentName];
+        // if no display state update parent color
         entry.forEach((displayState) => {
             if (idsToUpdate.includes(displayState.id)) {
                 displayState.color = newColor;

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -18,6 +18,7 @@ export interface SelectionEntry {
 export interface SelectionStateInfo {
     highlightedAgents: SelectionEntry[];
     hiddenAgents: SelectionEntry[];
+    colorChangeAgents: SelectionEntry[];
 }
 
 interface DisplayStateEntry {
@@ -215,6 +216,18 @@ class SelectionInterface {
             indices = [...indices, ...this.getIds(name, tags)];
         });
 
+        return indices;
+    }
+
+    public getColorChangeAgentIds(info: SelectionStateInfo): number[] {
+        const requests = info.colorChangeAgents;
+        let indices: number[] = [];
+
+        requests.forEach((r) => {
+            const name = r.name;
+            const tags = r.tags;
+            indices = [...indices, ...this.getIds(name, tags)];
+        });
         return indices;
     }
 

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -1,7 +1,6 @@
-import { filter, find, set, uniq } from "lodash";
+import { filter, find, uniq } from "lodash";
 import { EncodedTypeMapping } from "./types";
 import { convertColorNumberToString } from "../visGeometry/color-utils";
-import _ from "lodash";
 
 // An individual entry parsed from an encoded name
 // The encoded names can be just a name or a name plus a

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -232,16 +232,14 @@ class SelectionInterface {
     }
 
     public getUIDisplayData(): UIDisplayData {
-        let data = Object.keys(this.entries).map((name) => {
+        return Object.keys(this.entries).map((name) => {
             const displayStates: DisplayStateEntry[] = [];
             const encounteredTags: string[] = [];
             const hasMultipleStates =
                 Object.keys(this.entries[name]).length > 1;
-            // console.log(name, this.entries[name])
             this.entries[name].forEach((entry: DecodedTypeEntry) => {
                 // add unmodified state if there are multiple states, and one of them
                 // has no state tags
-                // console.log("entry", entry.id, "color", entry.color);
                 if (!entry.tags.length && hasMultipleStates) {
                     displayStates.push({
                         name: "<unmodified>",
@@ -270,17 +268,6 @@ class SelectionInterface {
                 color,
             };
         });
-
-        // console.log("deep clone of return value", _.cloneDeep(data));
-        // console.log("return value of getUiDisplayData", data);
-        // setTimeout(() => {
-        //     console.log(
-        //         "delayed deep clone of return value",
-        //         _.cloneDeep(data)
-        //     );
-        //     console.log("delayed return value of getUiDisplayData", data);
-        // }, 0);
-        return data;
     }
 
     private updateUiDataColor(
@@ -293,7 +280,6 @@ class SelectionInterface {
         // if no display state update parent color
         entry.forEach((displayState) => {
             if (idsToUpdate.includes(displayState.id)) {
-                console.log("updateUiDataColor");
                 displayState.color = newColor;
             }
         });

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -219,8 +219,8 @@ class SelectionInterface {
         return indices;
     }
 
-    public getColorChangeAgentIds(info: SelectionStateInfo): number[] {
-        const requests = info.colorChangeAgents;
+    public getColorChangeAgentIds(info: SelectionEntry[]): number[] {
+        const requests = info;
         let indices: number[] = [];
 
         requests.forEach((r) => {

--- a/src/simularium/index.ts
+++ b/src/simularium/index.ts
@@ -6,12 +6,7 @@ export type {
     EncodedTypeMapping,
     SimulariumFileFormat,
 } from "./types";
-export type {
-    SelectionStateInfo,
-    UIDisplayData,
-    ColorChanges,
-    SelectionEntry,
-} from "./SelectionInterface";
+export type { SelectionStateInfo, UIDisplayData } from "./SelectionInterface";
 export { ErrorLevel, FrontEndError } from "./FrontEndError";
 export { NetMessageEnum } from "./WebsocketClient";
 export { RemoteSimulator } from "./RemoteSimulator";

--- a/src/simularium/index.ts
+++ b/src/simularium/index.ts
@@ -6,7 +6,12 @@ export type {
     EncodedTypeMapping,
     SimulariumFileFormat,
 } from "./types";
-export type { SelectionStateInfo, UIDisplayData } from "./SelectionInterface";
+export type {
+    SelectionStateInfo,
+    UIDisplayData,
+    ColorChanges,
+    SelectionEntry,
+} from "./SelectionInterface";
 export { ErrorLevel, FrontEndError } from "./FrontEndError";
 export { NetMessageEnum } from "./WebsocketClient";
 export { RemoteSimulator } from "./RemoteSimulator";

--- a/src/test/SelectionInterface.test.ts
+++ b/src/test/SelectionInterface.test.ts
@@ -528,8 +528,8 @@ describe("SelectionInterface module", () => {
 
         test("it set the entry color to the 'unmodified' state color if provided", () => {
             // initially should have no color
-            expect(uiDisplayDataForA?.color).toEqual("");
-            expect(uiDisplayDataForB?.color).toEqual("");
+            expect(uiDisplayDataForA?.color).toEqual("#aaaaaa");
+            expect(uiDisplayDataForB?.color).toEqual("#bbbbbb");
             si.setInitialAgentColors(uiDisplayData, colorList, setColorForIds);
             expect(uiDisplayDataForA?.color).toEqual("#aaaaaa");
             expect(uiDisplayDataForB?.color).toEqual("#bbbbbb");

--- a/src/test/SelectionInterface.test.ts
+++ b/src/test/SelectionInterface.test.ts
@@ -23,10 +23,12 @@ const idMapping = {
 };
 
 const color = "";
-const initialColorChanges = {
-    agents: [],
-    color,
-};
+const initialColorChanges = [
+    {
+        agents: [],
+        color,
+    },
+];
 
 describe("SelectionInterface module", () => {
     describe("decode", () => {
@@ -427,9 +429,10 @@ describe("SelectionInterface module", () => {
             };
             const si = new SelectionInterface();
             si.parse(idMapping);
+            const uiDisplayData = si.getUIDisplayData();
             const oldColors = si.getColorsForName("A");
             expect(oldColors).not.toContain(newColor);
-            si.updateAgentColors(agentIds, colorChanges);
+            si.updateAgentColors(agentIds, colorChanges, uiDisplayData);
             const colors = si.getColorsForName("A");
             expect(colors).toContain(newColor);
         });

--- a/src/test/SelectionInterface.test.ts
+++ b/src/test/SelectionInterface.test.ts
@@ -231,6 +231,7 @@ describe("SelectionInterface module", () => {
                     { name: "D", tags: [] },
                 ],
                 hiddenAgents: [],
+                colorChangeAgents: [],
             };
             const ids = si.getHighlightedIds(selectionStateHighlight);
             const allAs = [0, 1, 2, 3];
@@ -250,6 +251,7 @@ describe("SelectionInterface module", () => {
                     { name: "D", tags: [""] },
                 ],
                 hiddenAgents: [],
+                colorChangeAgents: [],
             };
             const ids = si.getHighlightedIds(selectionStateHighlight);
 
@@ -266,6 +268,7 @@ describe("SelectionInterface module", () => {
                     { name: "E", tags: ["t1000"] },
                 ],
                 hiddenAgents: [],
+                colorChangeAgents: [],
             };
             const ids = si.getHighlightedIds(selectionStateHighlight);
 
@@ -278,6 +281,7 @@ describe("SelectionInterface module", () => {
             const selectionStateHighlight = {
                 highlightedAgents: [{ name: "E", tags: [""] }],
                 hiddenAgents: [],
+                colorChangeAgents: [],
             };
             const ids = si.getHighlightedIds(selectionStateHighlight);
 
@@ -295,6 +299,7 @@ describe("SelectionInterface module", () => {
                     { name: "A", tags: [] },
                     { name: "C", tags: [] },
                 ],
+                colorChangeAgents: [],
             };
             const ids = si.getHiddenIds(selectionStateHide);
 
@@ -310,6 +315,7 @@ describe("SelectionInterface module", () => {
                     { name: "A", tags: ["t1", "t2"] },
                     { name: "B", tags: ["t1"] },
                 ],
+                colorChangeAgents: [],
             };
             const ids = si.getHiddenIds(selectionStateHide);
             expect(ids).toEqual([1, 2, 3, 5, 7]);
@@ -325,8 +331,65 @@ describe("SelectionInterface module", () => {
                     { name: "A", tags: [""] },
                     { name: "C", tags: ["", "t1", "t2"] },
                 ],
+                colorChangeAgents: [],
             };
             const ids = si.getHiddenIds(selectionStateHide);
+
+            expect(ids).toEqual([0, 8, 9, 10, 11]);
+        });
+    });
+
+    describe("getColorChangeIds", () => {
+        test("Color change: select multiple by name", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const selectionStateColor = {
+                highlightedAgents: [],
+                hiddenAgents: [],
+                colorChangeAgents: [
+                    { name: "A", tags: [] },
+                    { name: "C", tags: [] },
+                ],
+            };
+            const ids = si.getColorChangeAgentIds(
+                selectionStateColor.colorChangeAgents
+            );
+
+            expect(ids).toEqual([0, 1, 2, 3, 8, 9, 10, 11]);
+        });
+
+        test("Color change: change color by name & tags", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const selectionStateColor = {
+                highlightedAgents: [],
+                hiddenAgents: [],
+                colorChangeAgents: [
+                    { name: "A", tags: ["t1", "t2"] },
+                    { name: "B", tags: ["t1"] },
+                ],
+            };
+            const ids = si.getColorChangeAgentIds(
+                selectionStateColor.colorChangeAgents
+            );
+            expect(ids).toEqual([1, 2, 3, 5, 7]);
+        });
+
+        test("Color change: change color by name & null tag", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+
+            const selectionStateColor = {
+                highlightedAgents: [],
+                hiddenAgents: [],
+                colorChangeAgents: [
+                    { name: "A", tags: [""] },
+                    { name: "C", tags: ["", "t1", "t2"] },
+                ],
+            };
+            const ids = si.getColorChangeAgentIds(
+                selectionStateColor.colorChangeAgents
+            );
 
             expect(ids).toEqual([0, 8, 9, 10, 11]);
         });
@@ -405,6 +468,8 @@ describe("SelectionInterface module", () => {
             );
         });
     });
+
+    describe("changeAgentColors", () => {});
 
     describe("setAgentColors", () => {
         const defaultColor = "#0";

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -321,8 +321,7 @@ class Viewport extends React.Component<
                 !isEqual(
                     selectionStateInfo.colorChangeAgents,
                     prevProps.selectionStateInfo.colorChangeAgents
-                )
-                ||
+                ) ||
                 !isEqual(this.props.assignedColor, prevProps.assignedColor)
             ) {
                 this.changeAgentColor(
@@ -561,7 +560,6 @@ class Viewport extends React.Component<
         agents: string | SelectionEntry[],
         color: string
     ): void {
-        // TODO: if color is not present in color array, add it
         if (typeof agents === "string") {
             agents = this.convertAgentNameToSelectionEntry(agents);
         }
@@ -594,8 +592,13 @@ class Viewport extends React.Component<
         }
         const typeCastAgentColors = agentColors as string[];
         if (!typeCastAgentColors.includes(color)) {
-            // todo: if color is not present in color array, add it
-            throw new Error("Color not found");
+            const uiDisplayData = this.selectionInterface.getUIDisplayData();
+            const updatedColors = this.selectionInterface.setAgentColors(
+                uiDisplayData,
+                [...agentColors, color],
+                this.visGeometry.setColorForIds.bind(this.visGeometry)
+            );
+            this.visGeometry.createMaterials(updatedColors);
         }
         const colorId = typeCastAgentColors.indexOf(color);
         return colorId;

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -42,7 +42,7 @@ type ViewportProps = {
     selectionStateInfo: SelectionStateInfo;
     showCameraControls: boolean;
     onError?: (error: FrontEndError) => void;
-    selectedColor: string;
+    assignedColor: string;
 } & Partial<DefaultProps>;
 
 const defaultProps = {
@@ -322,10 +322,12 @@ class Viewport extends React.Component<
                     selectionStateInfo.colorChangeAgents,
                     prevProps.selectionStateInfo.colorChangeAgents
                 )
+                ||
+                !isEqual(this.props.assignedColor, prevProps.assignedColor)
             ) {
                 this.changeAgentColor(
                     selectionStateInfo.colorChangeAgents,
-                    this.props.selectedColor
+                    this.props.assignedColor
                 );
             }
         }

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -41,6 +41,7 @@ type ViewportProps = {
     selectionStateInfo: SelectionStateInfo;
     showCameraControls: boolean;
     onError?: (error: FrontEndError) => void;
+    selectedColor: string;
 } & Partial<DefaultProps>;
 
 const defaultProps = {
@@ -314,6 +315,27 @@ class Viewport extends React.Component<
                 const hiddenIds =
                     this.selectionInterface.getHiddenIds(selectionStateInfo);
                 this.visGeometry.setVisibleByIds(hiddenIds);
+            }
+            if (
+                !isEqual(
+                    selectionStateInfo.colorChangeAgents,
+                    prevProps.selectionStateInfo.colorChangeAgents
+                )
+            ) {
+                const colorChangeAgentIds =
+                    this.selectionInterface.getColorChangeAgentIds(
+                        selectionStateInfo
+                    );
+                //get the selected color
+                let typeCastAgentColors = agentColors as string[];
+                let colorChangeColorId = typeCastAgentColors.indexOf(
+                    this.props.selectedColor
+                );
+                this.visGeometry.setColorForIds(
+                    colorChangeAgentIds,
+                    colorChangeColorId
+                );
+                this.visGeometry.setColorChangeByIds(colorChangeAgentIds);
             }
         }
 

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -566,7 +566,7 @@ class Viewport extends React.Component<
         } = this.props;
         colorChanges.forEach((colorChange) => {
             const { agents, color } = colorChange;
-            let uiDisplayData = this.selectionInterface.getUIDisplayData();
+            const uiDisplayData = this.selectionInterface.getUIDisplayData();
             const agentIds =
                 this.selectionInterface.getAgentIdsByNamesAndTags(agents);
        

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -19,7 +19,6 @@ import { FrontEndError, ErrorLevel } from "../simularium/FrontEndError";
 import { RenderStyle, VisGeometry, NO_AGENT } from "../visGeometry";
 import { ColorChanges } from "../simularium/SelectionInterface";
 
-
 export type PropColor = string | number | [number, number, number];
 
 type ViewportProps = {
@@ -202,18 +201,22 @@ class Viewport extends React.Component<
                 console.log("error parsing 'typeMapping' data", e);
             }
         }
+        const uiDisplayData = this.selectionInterface.getUIDisplayData();
+        // console.log("in on trajfileinfo", uiDisplayData);
         onTrajectoryFileInfoChanged(trajectoryFileInfo);
-            this.visGeometry.clearColorMapping();
-            const uiDisplayData = this.selectionInterface.getUIDisplayData();
-            const updatedColors = this.selectionInterface.setInitialAgentColors(
-                uiDisplayData,
-                agentColors,
-                this.visGeometry.setColorForIds.bind(this.visGeometry)
-            );
-            if (!isEqual(updatedColors, agentColors)) {
-                this.visGeometry.createMaterials(updatedColors);
-            }
-            onUIDisplayDataChanged(uiDisplayData);
+        this.visGeometry.clearColorMapping();
+
+        const updatedColors = this.selectionInterface.setInitialAgentColors(
+            uiDisplayData,
+            agentColors,
+            this.visGeometry.setColorForIds.bind(this.visGeometry)
+        );
+        if (!isEqual(updatedColors, agentColors)) {
+            this.visGeometry.createMaterials(updatedColors);
+        }
+
+        onUIDisplayDataChanged(uiDisplayData);
+        // console.log("in on trajfileinfo after on data changes", uiDisplayData);
     }
 
     public componentDidMount(): void {
@@ -322,6 +325,13 @@ class Viewport extends React.Component<
                     prevProps.selectionStateInfo.colorChanges
                 )
             ) {
+                // console.log(
+                //     "in update",
+                //     this.selectionInterface.getUIDisplayData()
+                // );
+                console.log(
+                    "firing change agents colors in component did update"
+                );
                 this.changeAgentsColor(selectionStateInfo.colorChanges);
             }
         }
@@ -560,18 +570,36 @@ class Viewport extends React.Component<
     }
 
     public changeAgentsColor(colorChanges: ColorChanges[]): void {
+        const {
+            onUIDisplayDataChanged,
+            agentColors,
+        } = this.props;
         colorChanges.forEach((colorChange) => {
             const { agents, color } = colorChange;
-        // const { agents, color } = colorChanges;
-        const agentIds =
-        this.selectionInterface.getAgentIdsByNamesAndTags(agents);
-        this.selectionInterface.updateAgentColors(agentIds, colorChange);
-        const colorId = this.getColorId(color);
-        this.visGeometry.applyColorToAgents(agentIds, colorId);
+            let uiDisplayData = this.selectionInterface.getUIDisplayData();
+            // console.log("uidisplay data in change agents color", uiDisplayData);
+            const agentIds =
+                this.selectionInterface.getAgentIdsByNamesAndTags(agents);
+       
+            this.selectionInterface.updateAgentColors(agentIds, colorChange, uiDisplayData);
+            const colorId = this.getColorId(color);
+            this.visGeometry.applyColorToAgents(agentIds, colorId);
+                //  this.selectionInterface.setInitialAgentColors(
+                //      uiDisplayData,
+                //      agentColors,
+                //      this.visGeometry.setColorForIds.bind(this.visGeometry)
+                //  );
+            const updatedUiDisplayData = this.selectionInterface.getUIDisplayData();
+            onUIDisplayDataChanged(updatedUiDisplayData);
+            console.log(
+                "uiDisplayData at end of change agents color",
+                updatedUiDisplayData
+            );
         });
     }
 
     public setColors(agentColors: string[] | number[]): void {
+        console.log("firing set colors")
         this.visGeometry.clearColorMapping();
         const uiDisplayData = this.selectionInterface.getUIDisplayData();
         const updatedColors = this.selectionInterface.setInitialAgentColors(

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -202,7 +202,6 @@ class Viewport extends React.Component<
             }
         }
         const uiDisplayData = this.selectionInterface.getUIDisplayData();
-        // console.log("in on trajfileinfo", uiDisplayData);
         onTrajectoryFileInfoChanged(trajectoryFileInfo);
         this.visGeometry.clearColorMapping();
 
@@ -215,8 +214,7 @@ class Viewport extends React.Component<
             this.visGeometry.createMaterials(updatedColors);
         }
 
-        onUIDisplayDataChanged(uiDisplayData);
-        // console.log("in on trajfileinfo after on data changes", uiDisplayData);
+        onUIDisplayDataChanged(this.selectionInterface.getUIDisplayData());
     }
 
     public componentDidMount(): void {
@@ -325,13 +323,6 @@ class Viewport extends React.Component<
                     prevProps.selectionStateInfo.colorChanges
                 )
             ) {
-                // console.log(
-                //     "in update",
-                //     this.selectionInterface.getUIDisplayData()
-                // );
-                console.log(
-                    "firing change agents colors in component did update"
-                );
                 this.changeAgentsColor(selectionStateInfo.colorChanges);
             }
         }
@@ -572,34 +563,22 @@ class Viewport extends React.Component<
     public changeAgentsColor(colorChanges: ColorChanges[]): void {
         const {
             onUIDisplayDataChanged,
-            agentColors,
         } = this.props;
         colorChanges.forEach((colorChange) => {
             const { agents, color } = colorChange;
             let uiDisplayData = this.selectionInterface.getUIDisplayData();
-            // console.log("uidisplay data in change agents color", uiDisplayData);
             const agentIds =
                 this.selectionInterface.getAgentIdsByNamesAndTags(agents);
        
             this.selectionInterface.updateAgentColors(agentIds, colorChange, uiDisplayData);
             const colorId = this.getColorId(color);
             this.visGeometry.applyColorToAgents(agentIds, colorId);
-                //  this.selectionInterface.setInitialAgentColors(
-                //      uiDisplayData,
-                //      agentColors,
-                //      this.visGeometry.setColorForIds.bind(this.visGeometry)
-                //  );
             const updatedUiDisplayData = this.selectionInterface.getUIDisplayData();
             onUIDisplayDataChanged(updatedUiDisplayData);
-            console.log(
-                "uiDisplayData at end of change agents color",
-                updatedUiDisplayData
-            );
         });
     }
 
     public setColors(agentColors: string[] | number[]): void {
-        console.log("firing set colors")
         this.visGeometry.clearColorMapping();
         const uiDisplayData = this.selectionInterface.getUIDisplayData();
         const updatedColors = this.selectionInterface.setInitialAgentColors(

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -561,7 +561,7 @@ class Viewport extends React.Component<
     ): void {
         // TODO: if color is not present in color array, add it
         if (typeof agents === "string") {
-            agents = this.selectionEntryFromAgentName(agents);
+            agents = this.convertAgentNameToSelectionEntry(agents);
         }
         const agentIds = this.selectionInterface.getColorChangeAgentIds(agents);
         const colorId = this.getColorId(
@@ -571,7 +571,7 @@ class Viewport extends React.Component<
         this.applyColorToAgents(agentIds, colorId);
     }
 
-    public selectionEntryFromAgentName(name: string): SelectionEntry[] {
+    public convertAgentNameToSelectionEntry(name: string): SelectionEntry[] {
         const uiDisplayData = this.selectionInterface.getUIDisplayData();
         const agentNames = uiDisplayData.map((a) => a.name);
         if (!agentNames.includes(name)) {

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -203,9 +203,17 @@ class Viewport extends React.Component<
             }
         }
         onTrajectoryFileInfoChanged(trajectoryFileInfo);
-        this.setColors(agentColors);
-        const uiDisplayData = this.selectionInterface.getUIDisplayData();
-        onUIDisplayDataChanged(uiDisplayData);
+            this.visGeometry.clearColorMapping();
+            const uiDisplayData = this.selectionInterface.getUIDisplayData();
+            const updatedColors = this.selectionInterface.setInitialAgentColors(
+                uiDisplayData,
+                agentColors,
+                this.visGeometry.setColorForIds.bind(this.visGeometry)
+            );
+            if (!isEqual(updatedColors, agentColors)) {
+                this.visGeometry.createMaterials(updatedColors);
+            }
+            onUIDisplayDataChanged(uiDisplayData);
     }
 
     public componentDidMount(): void {
@@ -551,14 +559,16 @@ class Viewport extends React.Component<
         return this.visGeometry.addNewColor(color);
     }
 
-    public changeAgentsColor(colorChanges: ColorChanges): void {
-        const { agents, color } = colorChanges;
+    public changeAgentsColor(colorChanges: ColorChanges[]): void {
+        colorChanges.forEach((colorChange) => {
+            const { agents, color } = colorChange;
+        // const { agents, color } = colorChanges;
         const agentIds =
         this.selectionInterface.getAgentIdsByNamesAndTags(agents);
-        this.selectionInterface.updateAgentColors(agentIds, colorChanges);
+        this.selectionInterface.updateAgentColors(agentIds, colorChange);
         const colorId = this.getColorId(color);
         this.visGeometry.applyColorToAgents(agentIds, colorId);
-
+        });
     }
 
     public setColors(agentColors: string[] | number[]): void {
@@ -572,7 +582,6 @@ class Viewport extends React.Component<
         if (!isEqual(updatedColors, agentColors)) {
             this.visGeometry.createMaterials(updatedColors);
         }
-        this.visGeometry.finalizeIdColorMapping();
     }
 
     public stopAnimate(): void {

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -578,19 +578,6 @@ class Viewport extends React.Component<
         });
     }
 
-    public setColors(agentColors: string[] | number[]): void {
-        this.visGeometry.clearColorMapping();
-        const uiDisplayData = this.selectionInterface.getUIDisplayData();
-        const updatedColors = this.selectionInterface.setInitialAgentColors(
-            uiDisplayData,
-            agentColors,
-            this.visGeometry.setColorForIds.bind(this.visGeometry)
-        );
-        if (!isEqual(updatedColors, agentColors)) {
-            this.visGeometry.createMaterials(updatedColors);
-        }
-    }
-
     public stopAnimate(): void {
         if (this.animationRequestID !== 0) {
             cancelAnimationFrame(this.animationRequestID);

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -203,17 +203,8 @@ class Viewport extends React.Component<
             }
         }
         onTrajectoryFileInfoChanged(trajectoryFileInfo);
-        this.visGeometry.clearColorMapping();
+        this.setColors(agentColors);
         const uiDisplayData = this.selectionInterface.getUIDisplayData();
-        const updatedColors = this.selectionInterface.setAgentColors(
-            uiDisplayData,
-            agentColors,
-            this.visGeometry.setColorForIds.bind(this.visGeometry)
-        );
-        if (!isEqual(updatedColors, agentColors)) {
-            this.visGeometry.createMaterials(updatedColors);
-        }
-        this.visGeometry.finalizeIdColorMapping();
         onUIDisplayDataChanged(uiDisplayData);
     }
 
@@ -592,16 +583,25 @@ class Viewport extends React.Component<
         }
         const typeCastAgentColors = agentColors as string[];
         if (!typeCastAgentColors.includes(color)) {
-            const uiDisplayData = this.selectionInterface.getUIDisplayData();
-            const updatedColors = this.selectionInterface.setAgentColors(
-                uiDisplayData,
-                [...agentColors, color],
-                this.visGeometry.setColorForIds.bind(this.visGeometry)
-            );
-            this.visGeometry.createMaterials(updatedColors);
+            const updatedColors = [...agentColors, color] as string[]
+            this.setColors(updatedColors);
         }
         const colorId = typeCastAgentColors.indexOf(color);
         return colorId;
+    }
+
+    public setColors(agentColors: string[] | number[]): void {
+         this.visGeometry.clearColorMapping();
+         const uiDisplayData = this.selectionInterface.getUIDisplayData();
+         const updatedColors = this.selectionInterface.setAgentColors(
+             uiDisplayData,
+             agentColors,
+             this.visGeometry.setColorForIds.bind(this.visGeometry)
+         );
+         if (!isEqual(updatedColors, agentColors)) {
+             this.visGeometry.createMaterials(updatedColors);
+         }
+         this.visGeometry.finalizeIdColorMapping();
     }
 
     public applyColorToAgents(agentIds: number[], colorId: number): void {

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -1154,9 +1154,11 @@ class VisGeometry {
          * @param colorId index into the color array
          */
 
-        //todo: this code is commented out for now to allow colors to be changed
-        // after the intitial mapping is finalized
-        // need to either make a new function or handle setting and resettting isIdColorMappingSet
+        //TODO: this is commented out because I'm unsure how best to handle this
+        // the purpose of this feature is to allow color mapping to be changed
+        // should we just remove this error handling? or should the color change methods
+        // clear the mapping, apply the color change then reset it?
+
         // if (this.isIdColorMappingSet) {
         //     throw new FrontEndError(
         //         "Attempted to set agent-color after color mapping was finalized"

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -116,6 +116,7 @@ class VisGeometry {
     public visAgentInstances: Map<number, VisAgent>;
     public fixLightsToCamera: boolean;
     public highlightedIds: number[];
+    public colorChangeIds: number[];
     public hiddenIds: number[];
     public agentPaths: Map<number, AgentPath>;
     public mlogger: ILogger;
@@ -187,6 +188,7 @@ class VisGeometry {
         this.visAgentInstances = new Map<number, VisAgent>();
         this.fixLightsToCamera = true;
         this.highlightedIds = [];
+        this.colorChangeIds = [];
         this.hiddenIds = [];
         this.needToCenterCamera = false;
         this.needToReOrientCamera = false;
@@ -724,6 +726,11 @@ class VisGeometry {
         this.updateScene(this.currentSceneAgents);
     }
 
+    public setColorChangeByIds(ids: number[]): void {
+        this.colorChangeIds = ids;
+        this.updateScene(this.currentSceneAgents);
+    }
+
     public dehighlight(): void {
         this.setHighlightByIds([]);
     }
@@ -1146,11 +1153,15 @@ class VisGeometry {
          * @param ids agent ids that should all have the same color
          * @param colorId index into the color array
          */
-        if (this.isIdColorMappingSet) {
-            throw new FrontEndError(
-                "Attempted to set agent-color after color mapping was finalized"
-            );
-        }
+
+        //todo: this code is commented out for now to allow colors to be changed
+        // after the intitial mapping is finalized
+        // need to either make a new function or handle setting and resettting isIdColorMappingSet
+        // if (this.isIdColorMappingSet) {
+        //     throw new FrontEndError(
+        //         "Attempted to set agent-color after color mapping was finalized"
+        //     );
+        // }
         ids.forEach((id) => this.setColorForId(id, colorId));
     }
 

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -146,7 +146,6 @@ class VisGeometry {
     public agentPathGroup: Group;
     public instancedMeshGroup: Group;
     public idColorMapping: Map<number, number>;
-    private isIdColorMappingSet: boolean;
     private supportsWebGL2Rendering: boolean;
     private lodBias: number;
     private lodDistanceStops: number[];
@@ -181,7 +180,6 @@ class VisGeometry {
         this.geometryStore = new GeometryStore(loggerLevel);
         this.scaleMapping = new Map<number, number>();
         this.idColorMapping = new Map<number, number>();
-        this.isIdColorMappingSet = false;
         this.followObjectId = NO_AGENT;
         this.visAgents = [];
         this.visAgentInstances = new Map<number, VisAgent>();
@@ -1134,7 +1132,6 @@ class VisGeometry {
 
     public clearColorMapping(): void {
         this.idColorMapping.clear();
-        this.isIdColorMappingSet = false;
     }
 
     private getColorIndexForTypeId(typeId: number): number {
@@ -1172,17 +1169,6 @@ class VisGeometry {
          * @param ids agent ids that should all have the same color
          * @param colorId index into the color array
          */
-
-        //TODO: this is commented out because I'm unsure how best to handle this
-        // the purpose of this feature is to allow color mapping to be changed
-        // should we just remove this error handling? or should the color change methods
-        // clear the mapping, apply the color change then reset it?
-
-        // if (this.isIdColorMappingSet) {
-        //     throw new FrontEndError(
-        //         "Attempted to set agent-color after color mapping was finalized"
-        //     );
-        // }
         ids.forEach((id) => this.setColorForId(id, colorId));
     }
 
@@ -1197,10 +1183,6 @@ class VisGeometry {
             this.colorsData[index * 4 + 1],
             this.colorsData[index * 4 + 2]
         );
-    }
-
-    public finalizeIdColorMapping(): void {
-        this.isIdColorMappingSet = true;
     }
 
     /**
@@ -1600,9 +1582,6 @@ class VisGeometry {
      *   Update Scene
      **/
     private updateScene(agents: AgentData[]): void {
-        if (!this.isIdColorMappingSet) {
-            return;
-        }
         this.currentSceneAgents = agents;
 
         // values for updating agent path


### PR DESCRIPTION
Problem
=======
Closes Set Agent Color [#148](https://github.com/simularium/simularium-viewer/issues/148)

Solution
========
In brief: colorChanges are now part of SelectionStateInfo. Viewer watches for changes to selectionStateInfo.colorChanges and calls changeAgentsColor in response to changes. changeAgentsColor updates visGeometry and UiDisplayData to ensure color changes are represented both in the viewport and in embedding applications that reference the UiDisplayData.

Added a few helper functions, cleaned unused ColorMapping in visGeo and made small updates to existing functions to accommodate new behavior.

Selection Interface:
- Added property to the SelectionEntry type so that it now includes colorChanges
- previous function setAgentColors divided into setInitialAgentColors and updateAgentColors

Viewport:
- ComponentDidUpdate checks for new colorChangeAgents and calls changeAgentsColor which is the primary method for this PR

VisGeometry:
- add applyColorToAgents and indexOfColor, remove unused ColorMapping functions

Example Viewer/ColorPicker.tsx
- Added a new component file to prevent further growth of massive Viewer.tsx file, maybe a refactor of Viewer.tsx into different components would be wise at some point

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Try it out in the example viewer: select agents (and optionally subagents), select a color, apply color to agent. New colors can be provided via input field.

