### PR TITLE
delay webgl init until after component mounted

### DIFF
--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -250,7 +250,6 @@ class VisGeometry {
         this.camera.position.z = DEFAULT_CAMERA_Z_POSITION;
         this.initCameraPosition = this.camera.position.clone();
 
-        //this.controls = this.setupControls();
         this.focusMode = true;
 
         this.tickIntervalLength = 0;

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -120,13 +120,13 @@ class VisGeometry {
     public agentPaths: Map<number, AgentPath>;
     public mlogger: ILogger;
     // this is the threejs object that issues all the webgl calls
-    public threejsrenderer: WebGLRenderer;
+    public threejsrenderer!: WebGLRenderer;
     public scene: Scene;
 
     public perspectiveCamera: PerspectiveCamera;
     public orthographicCamera: OrthographicCamera;
     public camera: PerspectiveCamera | OrthographicCamera;
-    public controls: OrbitControls;
+    public controls!: OrbitControls;
 
     public dl: DirectionalLight;
     public hemiLight: HemisphereLight;
@@ -228,40 +228,6 @@ class VisGeometry {
         this.hemiLight.position.set(0, 1, 0);
         this.lightsGroup.add(this.hemiLight);
 
-        // Set up renderer
-
-        if (WEBGL.isWebGL2Available() === false) {
-            this.renderStyle = RenderStyle.WEBGL1_FALLBACK;
-            this.supportsWebGL2Rendering = false;
-            this.threejsrenderer = new WebGLRenderer({
-                premultipliedAlpha: false,
-            });
-        } else {
-            this.renderStyle = RenderStyle.WEBGL2_PREFERRED;
-            this.supportsWebGL2Rendering = true;
-            const canvas = document.createElement("canvas");
-            const context: WebGLRenderingContext = canvas.getContext("webgl2", {
-                alpha: false,
-            }) as WebGLRenderingContext;
-
-            const rendererParams: WebGLRendererParameters = {
-                canvas: canvas,
-                context: context,
-                premultipliedAlpha: false,
-            };
-            this.threejsrenderer = new WebGLRenderer(rendererParams);
-        }
-
-        // set this up after the renderStyle has been set.
-        this.constructInstancedFibers();
-
-        this.threejsrenderer.setSize(
-            CANVAS_INITIAL_WIDTH,
-            CANVAS_INITIAL_HEIGHT
-        ); // expected to change when reparented
-        this.threejsrenderer.setClearColor(this.backgroundColor, 1);
-        this.threejsrenderer.clear();
-
         this.mlogger = jsLogger.get("visgeometry");
         this.mlogger.setLevel(loggerLevel);
 
@@ -284,7 +250,7 @@ class VisGeometry {
         this.camera.position.z = DEFAULT_CAMERA_Z_POSITION;
         this.initCameraPosition = this.camera.position.clone();
 
-        this.controls = this.setupControls();
+        //this.controls = this.setupControls();
         this.focusMode = true;
 
         this.tickIntervalLength = 0;
@@ -842,11 +808,48 @@ class VisGeometry {
         this.camera = newCam;
     }
 
+    private createWebGL(): WebGLRenderer {
+        if (WEBGL.isWebGL2Available() === false) {
+            this.renderStyle = RenderStyle.WEBGL1_FALLBACK;
+            this.supportsWebGL2Rendering = false;
+            this.threejsrenderer = new WebGLRenderer({
+                premultipliedAlpha: false,
+            });
+        } else {
+            this.renderStyle = RenderStyle.WEBGL2_PREFERRED;
+            this.supportsWebGL2Rendering = true;
+            const canvas = document.createElement("canvas");
+            const context: WebGLRenderingContext = canvas.getContext("webgl2", {
+                alpha: false,
+            }) as WebGLRenderingContext;
+
+            const rendererParams: WebGLRendererParameters = {
+                canvas: canvas,
+                context: context,
+                premultipliedAlpha: false,
+            };
+            this.threejsrenderer = new WebGLRenderer(rendererParams);
+        }
+
+        // set this up after the renderStyle has been set.
+        this.constructInstancedFibers();
+
+        this.threejsrenderer.setSize(
+            CANVAS_INITIAL_WIDTH,
+            CANVAS_INITIAL_HEIGHT
+        ); // expected to change when reparented
+        this.threejsrenderer.setClearColor(this.backgroundColor, 1);
+        this.threejsrenderer.clear();
+
+        return this.threejsrenderer;
+    }
+
     public reparent(parent?: HTMLElement | null): void {
         if (parent === undefined || parent == null) {
             return;
         }
 
+        this.threejsrenderer = this.createWebGL();
         parent.appendChild(this.threejsrenderer.domElement);
         this.setupControls();
 

--- a/src/visGeometry/rendering/RenderToBuffer.ts
+++ b/src/visGeometry/rendering/RenderToBuffer.ts
@@ -42,7 +42,7 @@ class RenderToBuffer {
             ].join("\n"),
             fragmentShader: paramsObj.fragmentShader,
             uniforms: paramsObj.uniforms,
-            defines: paramsObj.defines,
+            defines: paramsObj.defines || {},
         });
 
         // in order to guarantee the whole quad is drawn every time optimally:


### PR DESCRIPTION
Problem
=======
#326 the zoom/pan/rotate controls were not working as expected, due to changes from #319 .

Solution
========
Delay initialization of threejs WebGL until after component mount.  Then create OrbitControls and attach to the WebGL canvas element.   This has restored the correct functioning.  We were previously creating and re-creating webgl renderers and the canvases that go along with them.  

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* Need to re-test within simularium-website.  Also I noticed that resetCamera didn't seem to nicely bound every scene but I wasn't sure if it was a problem with the data or the code.  Will do more testing within context of the website app.

