### PR TITLE
add translation and rotation to fiber agents

### DIFF
--- a/examples/CurveSimulator.ts
+++ b/examples/CurveSimulator.ts
@@ -176,4 +176,6 @@ export default class CurveSim implements IClientSimulatorImpl {
             },
         };
     }
+
+    updateSimulationState(data: Record<string, unknown>) {}
 }

--- a/examples/MetaballSimulator.ts
+++ b/examples/MetaballSimulator.ts
@@ -182,4 +182,6 @@ export default class MetaballSimulator implements IClientSimulatorImpl {
             },
         };
     }
+
+    updateSimulationState(data: Record<string, unknown>) {}
 }

--- a/examples/PdbSimulator.ts
+++ b/examples/PdbSimulator.ts
@@ -214,4 +214,6 @@ export default class PdbSim implements IClientSimulatorImpl {
             },
         };
     }
+
+    updateSimulationState(data: Record<string, unknown>) {}
 }

--- a/examples/SingleCurveSimulator.ts
+++ b/examples/SingleCurveSimulator.ts
@@ -10,16 +10,14 @@ import {
 import VisTypes from "../src/simularium/VisTypes";
 import { DEFAULT_CAMERA_SPEC } from "../src/constants";
 
-export default class PointSim implements IClientSimulatorImpl {
-    nPoints: number;
-    pointsData: number[];
+export default class SingleCurveSim implements IClientSimulatorImpl {
+    curveData: number[];
+    nPointsPerCurve: number;
     currentFrame: number;
-    nTypes: number;
 
-    constructor(nPoints: number, nTypes: number) {
-        this.nPoints = nPoints;
-        this.nTypes = nTypes;
-        this.pointsData = this.makePoints(nPoints);
+    constructor() {
+        this.nPointsPerCurve = 5;
+        this.curveData = this.makeCurveBundle(1, this.nPointsPerCurve);
         this.currentFrame = 0;
     }
 
@@ -49,52 +47,70 @@ export default class PointSim implements IClientSimulatorImpl {
         ];
     }
 
-    private makePoints(nPoints) {
-        const pts: number[] = [];
-        let p: number[] = [];
-        for (let i = 0; i < nPoints; ++i) {
-            p = this.randomPtInBox(-4, 4, -4, 4, -4, 4);
-            pts.push(p[0]);
-            pts.push(p[1]);
-            pts.push(p[2]);
-        }
-        return pts;
+    private makeCurveBundle() {
+        // make one curve w/5 pts
+        const curves: number[] = [];
+        let p: number[];
+        p = this.randomPtInBox(-4, -3, -2, 2, -2, 2);
+        curves.push(p[0]);
+        curves.push(p[1]);
+        curves.push(p[2]);
+        p = this.randomPtInBox(-2.5, -2, -1, 1, -1, 1);
+        curves.push(p[0]);
+        curves.push(p[1]);
+        curves.push(p[2]);
+        p = this.randomPtInBox(-1, 1, -0.5, 0.5, -0.5, 0.5);
+        curves.push(p[0]);
+        curves.push(p[1]);
+        curves.push(p[2]);
+        p = this.randomPtInBox(2, 2.5, -1, 1, -1, 1);
+        curves.push(p[0]);
+        curves.push(p[1]);
+        curves.push(p[2]);
+        p = this.randomPtInBox(3, 4, -2, 2, -2, 2);
+        curves.push(p[0]);
+        curves.push(p[1]);
+        curves.push(p[2]);
+        return curves;
     }
 
     public update(_dt: number): VisDataMessage {
+        const nFloatsPerCurve = this.nPointsPerCurve * 3;
         //const dt_adjusted = dt / 1000;
         const amplitude = 0.05;
-        for (let ii = 0; ii < this.nPoints; ++ii) {
-            this.pointsData[ii * 3 + 0] += this.randomFloat(
+        for (let jj = 0; jj < this.nPointsPerCurve; ++jj) {
+            this.curveData[jj * 3 + 0] += this.randomFloat(
                 -amplitude,
                 amplitude
             );
-            this.pointsData[ii * 3 + 1] += this.randomFloat(
+            this.curveData[jj * 3 + 1] += this.randomFloat(
                 -amplitude,
                 amplitude
             );
-            this.pointsData[ii * 3 + 2] += this.randomFloat(
+            this.curveData[jj * 3 + 2] += this.randomFloat(
                 -amplitude,
                 amplitude
             );
         }
         // fill agent data.
         const agentData: number[] = [];
-        for (let ii = 0; ii < this.nPoints; ++ii) {
-            agentData.push(VisTypes.ID_VIS_TYPE_DEFAULT); // vis type
-            agentData.push(ii); // instance id
-            agentData.push(ii % this.nTypes); // type
-            agentData.push(this.pointsData[ii * 3 + 0]); // x
-            agentData.push(this.pointsData[ii * 3 + 1]); // y
-            agentData.push(this.pointsData[ii * 3 + 2]); // z
-            agentData.push(0); // rx
-            agentData.push(0); // ry
-            agentData.push(0); // rz
-            agentData.push(0.1); // collision radius
-            agentData.push(0); // subpoints
+        agentData.push(VisTypes.ID_VIS_TYPE_FIBER); // vis type
+        agentData.push(0); // instance id
+        agentData.push(0); // type
+        agentData.push(3.0 * Math.sin(this.currentFrame / 50)); // x
+        agentData.push(0); // y
+        agentData.push(0); // z
+        agentData.push(0); // rx
+        agentData.push(0); // ry
+        agentData.push(this.currentFrame / 50); // rz
+        agentData.push(0.3); // collision radius
+        agentData.push(nFloatsPerCurve);
+        for (let jj = 0; jj < nFloatsPerCurve; ++jj) {
+            agentData.push(this.curveData[jj]);
         }
+
         const frameData: VisDataMessage = {
-            // TODO get msgType out of here
+            // TODO get msgType and connId out of here
             msgType: ClientMessageEnum.ID_VIS_DATA_ARRIVE,
             bundleStart: this.currentFrame,
             bundleSize: 1, // frames
@@ -113,9 +129,7 @@ export default class PointSim implements IClientSimulatorImpl {
 
     public getInfo(): TrajectoryFileInfo {
         const typeMapping: EncodedTypeMapping = {};
-        for (let i = 0; i < this.nTypes; ++i) {
-            typeMapping[i] = { name: `point${i}` };
-        }
+        typeMapping[0] = { name: "fiber0" };
         return {
             // TODO get msgType and connId out of here
             connId: "hello world",

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -20,6 +20,7 @@ import PointSimulatorLive from "./PointSimulatorLive";
 import PdbSimulator from "./PdbSimulator";
 import SinglePdbSimulator from "./SinglePdbSimulator";
 import CurveSimulator from "./CurveSimulator";
+import SingleCurveSimulator from "./SingleCurveSimulator";
 import ColorPicker from "./ColorPicker";
 import {
     SMOLDYN_TEMPLATE,
@@ -536,6 +537,13 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 },
                 playbackFile
             );
+        } else if (playbackFile === "TEST_SINGLE_FIBER") {
+            simulariumController.changeFile(
+                {
+                    clientSimulator: new SingleCurveSimulator(),
+                },
+                playbackFile
+            );
         } else if (playbackFile === "TEST_PDB") {
             simulariumController.changeFile(
                 {
@@ -671,6 +679,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     </option>
                     <option value="TEST_SINGLE_PDB">TEST SINGLE PDB</option>
                     <option value="TEST_PDB">TEST PDB</option>
+                    <option value="TEST_SINGLE_FIBER">TEST SINGLE FIBER</option>
                     <option value="TEST_FIBERS">TEST FIBERS</option>
                     <option value="TEST_POINTS">TEST POINTS</option>
                     <option value="TEST_METABALLS">TEST METABALLS</option>

--- a/src/visGeometry/VisAgent.ts
+++ b/src/visGeometry/VisAgent.ts
@@ -155,17 +155,18 @@ export default class VisAgent {
     }
 
     public getFollowPosition(): Vector3 {
+        const pos = new Vector3(
+            this.agentData.x,
+            this.agentData.y,
+            this.agentData.z
+        );
         if (
             this.agentData["vis-type"] === VisTypes.ID_VIS_TYPE_FIBER &&
             this.fiberCurve
         ) {
-            return this.fiberCurve.getPoint(0.5);
+            return this.fiberCurve.getPoint(0.5).add(pos);
         } else {
-            return new Vector3(
-                this.agentData.x,
-                this.agentData.y,
-                this.agentData.z
-            );
+            return pos;
         }
     }
 }

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -1574,6 +1574,9 @@ class VisGeometry {
                 agentData.y,
                 agentData.z,
                 agentData.cr * scale * 0.5,
+                agentData.xrot,
+                agentData.yrot,
+                agentData.zrot,
                 visAgent.agentData.instanceId,
                 visAgent.signedTypeId()
             );

--- a/src/visGeometry/rendering/InstancedFiberShader.ts
+++ b/src/visGeometry/rendering/InstancedFiberShader.ts
@@ -12,6 +12,7 @@ in vec2 uv;
 
 // per instance attributes
 in vec4 translateAndScale; // xyz trans, w scale
+in vec4 rotation; // quaternion
 // instanceID, typeId, and which row of texture contains this curve
 in vec3 instanceAndTypeId;
 
@@ -305,6 +306,10 @@ void createTube (float t, vec2 volume, out vec3 offset, out vec3 normal) {
 }
 #endif
 
+vec3 applyQuaternionToVector( vec4 q, vec3 v ) {
+  return v + 2.0 * cross( q.xyz, cross( q.xyz, v ) + q.w * v );
+}
+
 void main() {
   // load the curve
   for (int i = 0; i < NUM_POINTS; ++i) {
@@ -329,6 +334,8 @@ void main() {
   // vUv = uv.yx; // swizzle this to match expectations
 
   // project our vertex position
+  transformed = applyQuaternionToVector(rotation, transformed);
+  transformed += translateAndScale.xyz;
   vec4 mvPosition = modelViewMatrix * vec4(transformed, 1.0);
 
   IN_viewPos = mvPosition.xyz;


### PR DESCRIPTION
Problem
=======
#332 
Up until now, fibers have been required to put their subpoints into fully transformed world space, and position and rotation required to be 0.  However, our updated fiber rendering does now support full transformations.

Solution
========
Add a code path to actually use agent position and rotation to transform fiber vertices.  Also add a simple javascript test simulator to demonstrate translation and rotation.

## Type of change

* New feature (non-breaking change which adds functionality)

Change summary:
---------------
Add transformation to the shader.  Add code path to send data in.  This required adding a whole new buffer for the rotation data.  This could be inefficient if rotations are nearly always 0 - we are just passing around a buffer of 0s and doing a little extra math with them.

Steps to Verify:
----------------
Can clone and select the "TEST_SINGLE_FIBER" in the demo viewer.

Screenshots (optional):
-----------------------

https://github.com/simularium/simularium-viewer/assets/2193409/3eae4d6d-529f-4dd6-8f80-fb4f3adbe993



