### PR TITLE
fix type exports

### DIFF
--- a/src/simularium/index.ts
+++ b/src/simularium/index.ts
@@ -5,6 +5,8 @@ export type {
     TrajectoryFileInfo,
     EncodedTypeMapping,
     SimulariumFileFormat,
+    SelectionEntry,
+    ColorChanges,
 } from "./types";
 export type { SelectionStateInfo, UIDisplayData } from "./SelectionInterface";
 export { ErrorLevel, FrontEndError } from "./FrontEndError";

--- a/src/simularium/index.ts
+++ b/src/simularium/index.ts
@@ -5,10 +5,13 @@ export type {
     TrajectoryFileInfo,
     EncodedTypeMapping,
     SimulariumFileFormat,
+} from "./types";
+export type {
+    SelectionStateInfo,
+    UIDisplayData,
     SelectionEntry,
     ColorChanges,
-} from "./types";
-export type { SelectionStateInfo, UIDisplayData } from "./SelectionInterface";
+} from "./SelectionInterface";
 export { ErrorLevel, FrontEndError } from "./FrontEndError";
 export { NetMessageEnum } from "./WebsocketClient";
 export { RemoteSimulator } from "./RemoteSimulator";

--- a/src/simularium/types.ts
+++ b/src/simularium/types.ts
@@ -177,13 +177,3 @@ export interface PlotConfig {
     metricsIdy?: number;
     scatterPlotMode?: string;
 }
-
-export interface SelectionEntry {
-    name: string;
-    tags: string[];
-}
-
-export interface ColorChanges {
-    agents: SelectionEntry[];
-    color: string;
-}

--- a/src/simularium/types.ts
+++ b/src/simularium/types.ts
@@ -177,3 +177,13 @@ export interface PlotConfig {
     metricsIdy?: number;
     scatterPlotMode?: string;
 }
+
+export interface SelectionEntry {
+    name: string;
+    tags: string[];
+}
+
+export interface ColorChanges {
+    agents: SelectionEntry[];
+    color: string;
+}


### PR DESCRIPTION
I merged changes for the Set Agent Colors feature that caused errors. 

ColorChanges and SelectionEntry types were not being exported properly,  I think this should fix it.

To check:
It was giving errors when running `npm run build` prior to fix, now I can build without seeing those errors, and the type check here in GitHub seems happy. Any other ways we should confirm?

Apologies for the slowdown this caused! 