### PR TITLE
change dropbox links

### DIFF
--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -46,12 +46,12 @@ describe("util", () => {
         });
     });
     describe("checkAndSanitizePath", () => {
-        test("it returns a url unmodified", () => {
+        test("it returns a non dropbox url unmodified", () => {
             const url = "http://www.url.com";
             const result = checkAndSanitizePath(url);
             expect(result).toEqual(url);
         });
-        test("it returns a dropbox url unmodified", () => {
+        test("it returns a dropbox url modified with dropboxusercontent", () => {
             const url =
                 "https://www.dropbox.com/scl/fi/xh3vmyt9d74cl5cbhqgpm/Antigen.obj?rlkey=key&dl=1";
             const expected =

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -51,6 +51,13 @@ describe("util", () => {
             const result = checkAndSanitizePath(url);
             expect(result).toEqual(url);
         });
+        test("it returns a dropbox url unmodified", () => {
+            const url =
+                "https://www.dropbox.com/scl/fi/xh3vmyt9d74cl5cbhqgpm/Antigen.obj?rlkey=key&dl=1";
+            const expected =
+                "https://dl.dropboxusercontent.com/scl/fi/xh3vmyt9d74cl5cbhqgpm/Antigen.obj?rlkey=key&dl=1";
+            expect(checkAndSanitizePath(url)).toEqual(expected);
+        });
         test("it returns a path with a forward slash unmodified", () => {
             const path = "/path/to/file.obj";
             const result = checkAndSanitizePath(path);

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,7 +37,11 @@ export const checkAndSanitizePath = (pathOrUrl: string): string => {
     const isUrlRegEX =
         /(https?:\/\/)([\w\-])+\.{1}([a-zA-Z]{2,63})([\/\w-]*)*\/?\??([^#\n\r]*)?#?([^\n\r]*)/g;
     if (isUrlRegEX.test(pathOrUrl)) {
-        return pathOrUrl;
+        let url = pathOrUrl;
+        if (url.includes("dropbox")) {
+            url = url.replace("www.dropbox.com", "dl.dropboxusercontent.com");
+        }
+        return url;
     } else if (/\B\//g.test(pathOrUrl)) {
         return pathOrUrl;
     }


### PR DESCRIPTION
Problem
=======
Dropbox links to OBJ files started having a CORS error

Solution
========
I replaced the `www.dropbox.com` with `dl.dropboxusercontent.com`
[based on this post](https://www.dropboxforum.com/t5/View-download-and-export/Shared-Link-quot-scl-quot-to-quot-s-quot/m-p/695266/highlight/true#M49151)
They do note in the post that `dl.dropboxusercontent.com` is an old style that they still support "for now" so we'll have to keep an eye on it. I did ask in the forum if they plan to address the CORS issue with the new link style, so we'll see what they say. 



## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* This change requires updated or new tests

Steps to Verify:
----------------
1. `npm start`
1. open test bed viewer 
2. drag and drop [this file](https://allencellscience.slack.com/archives/CMQFRJPPF/p1696971385939479?thread_ts=1696965553.287399&cid=CMQFRJPPF)
3. should see structures

Screenshots (optional):
-----------------------
<img width="515" alt="Screenshot 2023-10-11 at 10 16 41 AM" src="https://github.com/simularium/simularium-viewer/assets/5170636/184b756e-8454-4367-bc8b-b921dde7265f">

