### PR TITLE
Fix/orthographic camera ssao

### DIFF
--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -1003,7 +1003,12 @@ class VisGeometry {
             const v = new Vector3();
             this.boundingBox.getSize(v);
             const maxDim = Math.max(v.x, v.y, v.z);
-            this.renderer.setNearFar(this.boxNearZ, this.boxFarZ, maxDim);
+            // this.camera.zoom accounts for perspective vs ortho cameras
+            this.renderer.setNearFar(
+                this.boxNearZ,
+                this.boxFarZ,
+                maxDim * this.camera.zoom
+            );
             this.boundingBoxMesh.visible = false;
             this.tickMarksMesh.visible = false;
             this.agentPathGroup.visible = false;

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -1007,7 +1007,8 @@ class VisGeometry {
             this.renderer.setNearFar(
                 this.boxNearZ,
                 this.boxFarZ,
-                maxDim * this.camera.zoom
+                maxDim,
+                this.camera.zoom
             );
             this.boundingBoxMesh.visible = false;
             this.tickMarksMesh.visible = false;

--- a/src/visGeometry/rendering/SimulariumRenderer.ts
+++ b/src/visGeometry/rendering/SimulariumRenderer.ts
@@ -71,6 +71,7 @@ class SimulariumRenderer {
     private boundsNear: number;
     private boundsFar: number;
     private boundsMaxDim: number;
+    private cameraZoom: number;
 
     public constructor() {
         this.parameters = {
@@ -99,6 +100,7 @@ class SimulariumRenderer {
         this.boundsNear = 0.0;
         this.boundsFar = 100.0;
         this.boundsMaxDim = 100.0;
+        this.cameraZoom = 1.0;
 
         this.gbufferPass = new GBufferPass();
 
@@ -322,10 +324,16 @@ class SimulariumRenderer {
         this.drawBufferPass.resize(x, y);
     }
 
-    public setNearFar(n: number, f: number, boxMaxDim: number): void {
+    public setNearFar(
+        n: number,
+        f: number,
+        boxMaxDim: number,
+        cameraZoom: number
+    ): void {
         this.boundsNear = n;
         this.boundsFar = f;
         this.boundsMaxDim = boxMaxDim;
+        this.cameraZoom = cameraZoom;
     }
 
     public render(
@@ -343,7 +351,7 @@ class SimulariumRenderer {
         this.ssao1Pass.pass.material.uniforms.intensity.value =
             this.parameters.ao1.intensity;
         this.ssao1Pass.pass.material.uniforms.scale.value =
-            (this.parameters.ao1.scale * sceneSize) / 100.0;
+            (this.parameters.ao1.scale * sceneSize * this.cameraZoom) / 100.0;
         this.ssao1Pass.pass.material.uniforms.kernelRadius.value =
             this.parameters.ao1.kernelRadius;
         this.ssao1Pass.pass.material.uniforms.minResolution.value =


### PR DESCRIPTION
Problem
=======
fixes #329 

Solution
========
The AO parameters needed special consideration for the camera.zoom parameter which is part of the mediation between orthographic and perspective.  It will be sent in as a separate parameter so that it doesn't affect other depth-based effects.  There can still be a shift in the AO intensity when switching cameras but it's much much more subtle.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

