### PR TITLE
fix drag n drop in test viewer

### DIFF
--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -271,8 +271,8 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     const geoAssets = filesArr.reduce((acc, cur, index) => {
                         if (index !== simulariumFileIndex) {
                             acc[cur.name] = parsedFiles[index];
-                            return acc;
                         }
+                        return acc;
                     }, {});
                     const fileName = filesArr[simulariumFileIndex].name;
                     this.loadFile(simulariumFile, fileName, geoAssets);

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -334,7 +334,7 @@ export default class SimulariumController {
             throw new Error("File must be a .simularium file");
         }
 
-        if (geoAssets && geoAssets.length) {
+        if (geoAssets) {
             return this.changeFile({ simulariumFile, geoAssets }, fileName);
         } else {
             return this.changeFile({ simulariumFile }, fileName);


### PR DESCRIPTION
Problem
=======
Drag and drop with multiple geometry assets was not working in the testbed viewer.

Solution
========
The test viewer uses a slightly different code path than the simularium-website viewer for loading from drag and drop.  It was checking a data structure in the wrong way, assuming it was an array instead of a keyed object.  This resulted in it ignoring the provided geometry files.
(As far as I can tell, this code path is unused by the website client so it should be totally safe.  It was needed to debug a different issue with meshes)

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Drag and drop a .simularium file accompanied by its necessary .obj meshes.
2. In the bug case, the meshes totally fail to load. 

