### PR TITLE
Update net connection settings to use wss for octopus

### DIFF
--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -184,14 +184,14 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 serverIp: "0.0.0.0",
                 serverPort: 8765,
                 useOctopus: props.useOctopus,
-                secureConnection: false,
+                secureConnection: props.useOctopus,
             };
         } else if (props.useOctopus) {
             this.netConnectionSettings = {
                 serverIp: "18.223.108.15",
                 serverPort: 8765,
-                useOctopus: props.useOctopus,
-                secureConnection: false,
+                useOctopus: true,
+                secureConnection: true,
             };
         } else {
             this.netConnectionSettings = {


### PR DESCRIPTION
Once [this PR](https://github.com/simularium/octopus/pull/47) merges, octopus will be using WSS instead of WS! So let's update the viewer to work with that :)

This shouldn't be merged until the aforementioned octopus PR is merged

Kinda part of [this ticket](https://github.com/simularium/octopus/issues/44)