### PR TITLE
Feature/server health check

### DIFF
--- a/examples/ConversionForm/index.tsx
+++ b/examples/ConversionForm/index.tsx
@@ -6,6 +6,7 @@ interface InputFormProps {
     template: { [key: string]: any };
     templateData: { [key: string]: any };
     type: string;
+    submitDisabled: boolean;
     submitFile: (data) => void;
     onReturned: () => void;
 }
@@ -59,7 +60,7 @@ class InputForm extends React.Component<InputFormProps> {
     }
 
     render() {
-        const { template, templateData, type } = this.props;
+        const { template, templateData, type, submitDisabled } = this.props;
         return (
             <div>
                 <h2>Enter display data for your {type} trajectory</h2>
@@ -78,7 +79,7 @@ class InputForm extends React.Component<InputFormProps> {
                         );
                     }
                 })}
-                <button type="submit" onClick={this.handleSubmit}>
+                <button type="submit" onClick={this.handleSubmit} disabled={submitDisabled}>
                     Submit
                 </button>
             </div>

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -187,14 +187,14 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 serverIp: "0.0.0.0",
                 serverPort: 8765,
                 useOctopus: props.useOctopus,
-                secureConnection: props.useOctopus,
+                secureConnection: false,
             };
         } else if (props.useOctopus) {
             this.netConnectionSettings = {
                 serverIp: "18.223.108.15",
                 serverPort: 8765,
-                useOctopus: true,
-                secureConnection: true,
+                useOctopus: props.useOctopus,
+                secureConnection: false,
             };
         } else {
             this.netConnectionSettings = {

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -184,14 +184,14 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 serverIp: "0.0.0.0",
                 serverPort: 8765,
                 useOctopus: props.useOctopus,
-                secureConnection: false,
+                secureConnection: props.useOctopus,
             };
         } else if (props.useOctopus) {
             this.netConnectionSettings = {
                 serverIp: "18.223.108.15",
                 serverPort: 8765,
-                useOctopus: props.useOctopus,
-                secureConnection: false,
+                useOctopus: true,
+                secureConnection: true,
             };
         } else {
             this.netConnectionSettings = {

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -235,9 +235,7 @@ export default class SimulariumController {
     ): Promise<void> {
         try {
             if (
-                !this.simulator ||
-                !(this.simulator instanceof RemoteSimulator) ||
-                !this.simulator.socketIsValid()
+                !(this.simulator && this.simulator.isConnectedToRemoteServer())
             ) {
                 // Only configure network if we aren't already connected to the remote server
                 this.configureNetwork(netConnectionConfig);
@@ -423,15 +421,11 @@ export default class SimulariumController {
         handler: () => void,
         netConnectionConfig: NetConnectionParams
     ): void {
-        if (
-            !this.simulator ||
-            !(this.simulator instanceof RemoteSimulator) ||
-            !this.simulator.socketIsValid()
-        ) {
+        if (!(this.simulator && this.simulator.isConnectedToRemoteServer())) {
             // Only configure network if we aren't already connected to the remote server
             this.configureNetwork(netConnectionConfig);
         }
-        if (this.simulator && this.simulator instanceof RemoteSimulator) {
+        if (this.simulator instanceof RemoteSimulator) {
             this.simulator.setHealthCheckHandler(handler);
             this.simulator.checkServerHealth();
         }

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -234,7 +234,14 @@ export default class SimulariumController {
         fileType: TrajectoryType
     ): Promise<void> {
         try {
-            this.configureNetwork(netConnectionConfig);
+            if (
+                !this.simulator ||
+                !(this.simulator instanceof RemoteSimulator) ||
+                !this.simulator.socketIsValid()
+            ) {
+                // Only configure network if we aren't already connected to the remote server
+                this.configureNetwork(netConnectionConfig);
+            }
             if (!(this.simulator instanceof RemoteSimulator)) {
                 throw new Error("Autoconversion requires a RemoteSimulator");
             }
@@ -410,6 +417,24 @@ export default class SimulariumController {
 
     public getFile(): string {
         return this.playBackFile;
+    }
+
+    public checkServerHealth(
+        handler: () => void,
+        netConnectionConfig: NetConnectionParams
+    ): void {
+        if (
+            !this.simulator ||
+            !(this.simulator instanceof RemoteSimulator) ||
+            !this.simulator.socketIsValid()
+        ) {
+            // Only configure network if we aren't already connected to the remote server
+            this.configureNetwork(netConnectionConfig);
+        }
+        if (this.simulator && this.simulator instanceof RemoteSimulator) {
+            this.simulator.setHealthCheckHandler(handler);
+            this.simulator.checkServerHealth();
+        }
     }
 
     private setupMetricsCalculator(

--- a/src/simularium/ClientSimulator.ts
+++ b/src/simularium/ClientSimulator.ts
@@ -63,6 +63,10 @@ export class ClientSimulator implements ISimulator {
         return "";
     }
 
+    public isConnectedToRemoteServer(): boolean {
+        return false;
+    }
+
     public connectToRemoteServer(_address: string): Promise<string> {
         return Promise.resolve("Local client sim successfully started");
     }

--- a/src/simularium/ISimulator.ts
+++ b/src/simularium/ISimulator.ts
@@ -20,6 +20,7 @@ export interface ISimulator {
      * */
     connectToRemoteServer(address: string): Promise<string>;
     socketIsValid(): boolean;
+    isConnectedToRemoteServer(): boolean;
     getIp(): string;
     disconnect(): void;
 

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -57,6 +57,10 @@ export class LocalFileSimulator implements ISimulator {
         return "";
     }
 
+    public isConnectedToRemoteServer(): boolean {
+        return false;
+    }
+
     public connectToRemoteServer(_address: string): Promise<string> {
         return Promise.resolve("Local file successfully started");
     }

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -143,15 +143,14 @@ export class RemoteSimulator implements ISimulator {
         // TODO: implement callback
     }
 
-    public onErrorMsg(msg: NetMessage): void {
-        const e = msg as ErrorMessage;
+    public onErrorMsg(msg: ErrorMessage): void {
         this.logger.error(
             "Error message of type ",
-            e.errorCode,
+            msg.errorCode,
             " arrived: ",
-            e.errorMsg
+            msg.errorMsg
         );
-        const error = new FrontEndError(e.errorMsg, ErrorLevel.WARNING);
+        const error = new FrontEndError(msg.errorMsg, ErrorLevel.WARNING);
         this.handleError(error);
         // TODO: specific handling based on error code
     }
@@ -201,7 +200,7 @@ export class RemoteSimulator implements ISimulator {
 
         this.webSocketClient.addJsonMessageHandler(
             NetMessageEnum.ID_ERROR_MSG,
-            (msg) => this.onErrorMsg(msg)
+            (msg) => this.onErrorMsg(msg as ErrorMessage)
         );
     }
 

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -7,6 +7,7 @@ import {
     NetMessageEnum,
     MessageEventLike,
     NetMessage,
+    ErrorMessage,
 } from "./WebsocketClient";
 import { ISimulator } from "./ISimulator";
 import { TrajectoryFileInfoV2, VisDataMessage } from "./types";
@@ -142,7 +143,7 @@ export class RemoteSimulator implements ISimulator {
         // TODO: implement callback
     }
 
-    public onErrorMsg(msg): void {
+    public onErrorMsg(msg: ErrorMessage): void {
         this.logger.error(
             "Error message of type ",
             msg.errorCode,
@@ -151,6 +152,7 @@ export class RemoteSimulator implements ISimulator {
         );
         const error = new FrontEndError(msg.errorMsg, ErrorLevel.WARNING);
         this.handleError(error);
+        // TODO: specific handling based on error code
     }
 
     private registerBinaryMessageHandlers(): void {

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -460,7 +460,9 @@ export class RemoteSimulator implements ISimulator {
                 );
             })
             .catch((e) => {
-                throw new FrontEndError(e.message, ErrorLevel.ERROR);
+                this.handleError(
+                    new FrontEndError(e.message, ErrorLevel.WARNING)
+                );
             });
     }
 }

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -215,6 +215,10 @@ export class RemoteSimulator implements ISimulator {
         return this.webSocketClient.getIp();
     }
 
+    public isConnectedToRemoteServer(): boolean {
+        return this.socketIsValid();
+    }
+
     public async connectToRemoteServer(): Promise<string> {
         this.registerBinaryMessageHandlers();
         this.registerJsonMessageHandlers();

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -7,6 +7,7 @@ import {
     NetMessageEnum,
     MessageEventLike,
     NetMessage,
+    ErrorMessage,
 } from "./WebsocketClient";
 import { ISimulator } from "./ISimulator";
 import { TrajectoryFileInfoV2, VisDataMessage } from "./types";
@@ -142,15 +143,13 @@ export class RemoteSimulator implements ISimulator {
         // TODO: implement callback
     }
 
-    public onErrorMsg(msg: NetMessage): void {
+    public onErrorMsg(msg: ErrorMessage): void {
         this.logger.error(
             "Error message of type ",
             msg.errorCode,
             " arrived: ",
             msg.errorMsg
         );
-        const error = new FrontEndError(msg.errorMsg, ErrorLevel.WARNING);
-        this.handleError(error);
         // TODO: specific handling based on error code
     }
 

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -7,7 +7,6 @@ import {
     NetMessageEnum,
     MessageEventLike,
     NetMessage,
-    ErrorMessage,
 } from "./WebsocketClient";
 import { ISimulator } from "./ISimulator";
 import { TrajectoryFileInfoV2, VisDataMessage } from "./types";
@@ -143,7 +142,7 @@ export class RemoteSimulator implements ISimulator {
         // TODO: implement callback
     }
 
-    public onErrorMsg(msg: ErrorMessage): void {
+    public onErrorMsg(msg: NetMessage): void {
         this.logger.error(
             "Error message of type ",
             msg.errorCode,

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -357,6 +357,9 @@ export class RemoteSimulator implements ISimulator {
     }
 
     public abortRemoteSim(): void {
+        if (!this.socketIsValid()) {
+            return;
+        }
         this.webSocketClient.sendWebSocketRequest(
             {
                 msgType: NetMessageEnum.ID_VIS_DATA_ABORT,

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -143,13 +143,16 @@ export class RemoteSimulator implements ISimulator {
         // TODO: implement callback
     }
 
-    public onErrorMsg(msg: ErrorMessage): void {
+    public onErrorMsg(msg: NetMessage): void {
+        const e = msg as ErrorMessage;
         this.logger.error(
             "Error message of type ",
-            msg.errorCode,
+            e.errorCode,
             " arrived: ",
-            msg.errorMsg
+            e.errorMsg
         );
+        const error = new FrontEndError(e.errorMsg, ErrorLevel.WARNING);
+        this.handleError(error);
         // TODO: specific handling based on error code
     }
 

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -141,6 +141,17 @@ export class RemoteSimulator implements ISimulator {
         this.serverHealthy = true;
     }
 
+    public onErrorMsg(msg): void {
+        this.logger.error(
+            "Error message of type ",
+            msg.errorCode,
+            " arrived: ",
+            msg.errorMsg
+        );
+        const error = new FrontEndError(msg.errorMsg, ErrorLevel.WARNING);
+        this.handleError(error);
+    }
+
     private registerBinaryMessageHandlers(): void {
         this.webSocketClient.addBinaryMessageHandler(
             NetMessageEnum.ID_VIS_DATA_ARRIVE,
@@ -182,6 +193,11 @@ export class RemoteSimulator implements ISimulator {
         this.webSocketClient.addJsonMessageHandler(
             NetMessageEnum.ID_SERVER_HEALTHY_RESPONSE,
             (_msg) => this.onHealthCheckResponse()
+        );
+
+        this.webSocketClient.addJsonMessageHandler(
+            NetMessageEnum.ID_ERROR_MSG,
+            (msg) => this.onErrorMsg(msg)
         );
     }
 

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -341,9 +341,6 @@ export class RemoteSimulator implements ISimulator {
     }
 
     public abortRemoteSim(): void {
-        if (!this.socketIsValid()) {
-            return;
-        }
         this.webSocketClient.sendWebSocketRequest(
             {
                 msgType: NetMessageEnum.ID_VIS_DATA_ABORT,

--- a/src/simularium/WebsocketClient.ts
+++ b/src/simularium/WebsocketClient.ts
@@ -7,6 +7,12 @@ export interface NetMessage {
     msgType: number;
     fileName: string;
 }
+
+export interface ErrorMessage {
+    msgType: number;
+    errorCode: number;
+    errorMsg: string;
+}
 // TODO: proposed new NetMessage data type:
 // This factors the raw data structure away from the networking and transmission info.
 // This allows the data structure to make a bit more sense with respect to typescript typing,
@@ -51,6 +57,18 @@ export const enum NetMessageEnum {
     ID_CHECK_HEALTH_REQUEST = 22,
     ID_SERVER_HEALTHY_RESPONSE = 23,
     // insert new values here before LENGTH
+    LENGTH,
+}
+
+export const enum ServerErrorCodes {
+    FILE_NOT_FOUND = 0,
+    MALFORMED_MESSAGE = 1,
+    MALFORMED_FILE = 2,
+    AUTOCONVERSION_ERROR = 3,
+    METRICS_CALC_ERROR = 4,
+    FRAME_NOT_FOUND = 5,
+    FILENAME_MISMATCH = 6,
+    NO_RUNNING_SIMULATION = 7,
     LENGTH,
 }
 

--- a/src/simularium/WebsocketClient.ts
+++ b/src/simularium/WebsocketClient.ts
@@ -6,10 +6,6 @@ export interface NetMessage {
     connId: string;
     msgType: number;
     fileName: string;
-}
-
-export interface ErrorMessage {
-    msgType: number;
     errorCode: number;
     errorMsg: string;
 }

--- a/src/simularium/WebsocketClient.ts
+++ b/src/simularium/WebsocketClient.ts
@@ -47,6 +47,9 @@ export const enum NetMessageEnum {
     ID_AVAILABLE_METRICS_RESPONSE = 18,
     ID_PLOT_DATA_REQUEST = 19,
     ID_PLOT_DATA_RESPONSE = 20,
+    ID_ERROR_MSG = 21,
+    ID_CHECK_HEALTH_REQUEST = 22,
+    ID_SERVER_HEALTHY_RESPONSE = 23,
     // insert new values here before LENGTH
     LENGTH,
 }

--- a/src/simularium/WebsocketClient.ts
+++ b/src/simularium/WebsocketClient.ts
@@ -6,9 +6,13 @@ export interface NetMessage {
     connId: string;
     msgType: number;
     fileName: string;
+}
+
+export interface ErrorMessage extends NetMessage {
     errorCode: number;
     errorMsg: string;
 }
+
 // TODO: proposed new NetMessage data type:
 // This factors the raw data structure away from the networking and transmission info.
 // This allows the data structure to make a bit more sense with respect to typescript typing,

--- a/src/simularium/WebsocketClient.ts
+++ b/src/simularium/WebsocketClient.ts
@@ -316,7 +316,7 @@ export class WebsocketClient {
         jsonData: Record<string, unknown>,
         requestDescription: string
     ): void {
-        if (this.socketIsValid()) {
+        if (this.socketIsConnected()) {
             if (this.webSocket !== null) {
                 this.webSocket.send(JSON.stringify(jsonData));
             }


### PR DESCRIPTION
Problem
=======
The server health check has existed in Octopus for a while now, time to take it in to the viewer!

One part of this [ticket](https://github.com/simularium/simularium-website/issues/389). The other piece of that ticket will include adding a health check call, similar to the one implemented here in the example viewer, to the simualrium-website in the early stages of the autoconversion form.

Also added in support for handling error messages octopus sends now, which is another new message type that has existed in Octopus for a bit.

Solution
========
Paired on this with with @interim17 

## Type of change
* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* Added handling for new message types that come from octopus: `ID_ERROR_MSG = 21` and `ID_SERVER_HEALTHY_RESPONSE = 23`
* Added ability to request health check, using new message type `ID_CHECK_HEALTH_REQUEST = 22`, which octopus already knows how to handle
* Added an example of using the health check request / response to the example viewer. Now, when you hit the "Load a smoldyn trajectory" button, a websocket connection will be initiated and health check request will be sent to octopus. The "submit" button will remain disabled until a server healthy response comes back
* As part of the changes to the example, I updated the autoconversion request call to only initiate a new websocket connection if there isn't already one there. Previously, we just automatically created a new websocket connection, but in the case that one may already exist from the server health check, we should just reuse that one 

