### PR TITLE
export modelinfo from index.ts

### DIFF
--- a/src/simularium/index.ts
+++ b/src/simularium/index.ts
@@ -3,6 +3,7 @@ export type {
     VisDataMessage,
     VisDataFrame,
     TrajectoryFileInfo,
+    ModelInfo,
     EncodedTypeMapping,
     SimulariumFileFormat,
 } from "./types";


### PR DESCRIPTION
Jupyter notebook viewer needs to import `ModelInfo` interface so moving it to top level exports