### PR TITLE
cd to examples folder to run build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "start": "npm run build && cd examples && npm run serve-example",
         "install-examples": "npm install && cd examples && npm install",
-        "gh-build": "npm-run-all processCSS && cd examples && npm run build-example",
+        "gh-build": "npm run processCSS && cd examples && npm run build-example",
         "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
         "test": "jest --coverage",
         "typeCheck": "tsc -p tsconfig.json --noEmit",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "start": "npm run build && cd examples && npm run serve-example",
         "install-examples": "npm install && cd examples && npm install",
-        "gh-build": "npm-run-all processCSS build-example",
+        "gh-build": "npm-run-all processCSS && cd examples && npm run build-example",
         "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
         "test": "jest --coverage",
         "typeCheck": "tsc -p tsconfig.json --noEmit",


### PR DESCRIPTION
New script for building test-bed viewer: `gh-build` wasn't finding `build example` command without a `cd` down a level into `/examples`

```> @aics/simularium-viewer@3.6.4 gh-build
> npm-run-all processCSS build-example

ERROR: Task not found: "build-example"