### PR TITLE
add viewer method to disable pan functionality

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -547,6 +547,10 @@ export default class SimulariumController {
         this.visGeometry?.setPanningMode(pan);
     }
 
+    public disablePan(): void {
+        this.visGeometry?.disablePan();
+    }
+
     public setFocusMode(focus: boolean): void {
         this.visGeometry?.setFocusMode(focus);
     }

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -638,6 +638,10 @@ class VisGeometry {
         }
     }
 
+    public disablePan(): void {
+        this.controls.enablePan = false;
+    }
+
     public setFocusMode(focus: boolean): void {
         this.focusMode = focus;
     }


### PR DESCRIPTION
NBSV designs specify that Pan functionality should be disabled, so we need to expose a viewer method to set `controls.enablePan = false`

If we anticipate front end applications that would want to more flexibly enable/disable pan, rotate, or dolly we could generalize this later, but this is all we need for NBSV MVP.