### PR TITLE
Fix/create root

### DIFF
--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -1,12 +1,17 @@
-import ReactDOM from "react-dom";
 import React from "react";
+import { createRoot } from "react-dom/client";
 
 import Viewer from './Viewer';
 
 declare const SIMULARIUM_USE_OCTOPUS: boolean;
 declare const SIMULARIUM_USE_LOCAL_BACKEND: boolean;
 
-ReactDOM.render(
-        <Viewer useOctopus={SIMULARIUM_USE_OCTOPUS} localBackendServer={SIMULARIUM_USE_LOCAL_BACKEND}/>,
-    document.getElementById("root")
+const container: HTMLElement | null = document.getElementById("root");
+
+const root = createRoot(container!);
+root.render(
+    <Viewer
+        useOctopus={SIMULARIUM_USE_OCTOPUS}
+        localBackendServer={SIMULARIUM_USE_LOCAL_BACKEND}
+    />
 );

--- a/src/simularium/FrameRecorder.ts
+++ b/src/simularium/FrameRecorder.ts
@@ -53,7 +53,7 @@ export class FrameRecorder {
                     },
                 });
                 const config: VideoEncoderConfig = {
-                    codec: "av01.0.04M.08",
+                    codec: "avc1.420028",
                     width: canvas.width,
                     height: canvas.height,
                 };
@@ -68,7 +68,7 @@ export class FrameRecorder {
                 this.muxer = new Muxer({
                     target: new ArrayBufferTarget(),
                     video: {
-                        codec: "av1",
+                        codec: "avc",
                         width: canvas.width,
                         height: canvas.height,
                     },

--- a/src/simularium/FrameRecorder.ts
+++ b/src/simularium/FrameRecorder.ts
@@ -53,7 +53,7 @@ export class FrameRecorder {
                     },
                 });
                 const config: VideoEncoderConfig = {
-                    codec: "avc1.420028",
+                    codec: "av01.0.04M.08",
                     width: canvas.width,
                     height: canvas.height,
                 };
@@ -68,7 +68,7 @@ export class FrameRecorder {
                 this.muxer = new Muxer({
                     target: new ArrayBufferTarget(),
                     video: {
-                        codec: "avc",
+                        codec: "av1",
                         width: canvas.width,
                         height: canvas.height,
                     },


### PR DESCRIPTION
Test-bed viewer was not actually running React 18 because the render API hadn't been switched over to `createRoot`, meaning we were in React 17 legacy mode, this makes that change.

Note: codec issues solved in separate PR, this is just the React change now