### PR TITLE
Fix/video config

### DIFF
--- a/src/simularium/FrameRecorder.ts
+++ b/src/simularium/FrameRecorder.ts
@@ -37,8 +37,8 @@ export class FrameRecorder {
     private async setup(): Promise<void> {
         const canvas = this.getCanvas();
         if (canvas) {
-            const roundedWidth = Math.ceil(canvas.width / 2) * 2;
-            const roundedHeight = Math.ceil(canvas.height / 2) * 2;
+            const evenWidth = Math.ceil(canvas.width / 2) * 2;
+            const evenHeight = Math.ceil(canvas.height / 2) * 2;
             try {
                 // VideoEncoder sends chunks of frame data to the muxer.
                 // Previously made one encoder in the constructor but
@@ -56,12 +56,12 @@ export class FrameRecorder {
                 });
                 const config: VideoEncoderConfig = {
                     // High profile, level 4. Could switch to lower level if latency seems to be an issue
+                    // default bitrate mode "variable" is fine for our purposes, to value quality > file size
                     codec: "avc1.640028",
-                    width: roundedWidth,
-                    height: roundedHeight,
+                    width: evenWidth,
+                    height: evenHeight,
                     framerate: this.frameRate,
-                    bitrate: 1e7,
-                    bitrateMode: "variable",
+                    bitrate: 2.5e7, // 25 Mbps
                     latencyMode: "realtime",
                 };
                 const { supported, config: supportedConfig } =

--- a/src/simularium/FrameRecorder.ts
+++ b/src/simularium/FrameRecorder.ts
@@ -61,7 +61,7 @@ export class FrameRecorder {
                     height: roundedHeight,
                     framerate: this.frameRate,
                     bitrate: 1e7,
-                    bitrateMode: "constant",
+                    bitrateMode: "variable",
                     latencyMode: "realtime",
                 };
                 const { supported, config: supportedConfig } =

--- a/src/simularium/FrameRecorder.ts
+++ b/src/simularium/FrameRecorder.ts
@@ -37,6 +37,8 @@ export class FrameRecorder {
     private async setup(): Promise<void> {
         const canvas = this.getCanvas();
         if (canvas) {
+            const roundedWidth = Math.ceil(canvas.width / 2) * 2;
+            const roundedHeight = Math.ceil(canvas.height / 2) * 2;
             try {
                 // VideoEncoder sends chunks of frame data to the muxer.
                 // Previously made one encoder in the constructor but
@@ -53,9 +55,14 @@ export class FrameRecorder {
                     },
                 });
                 const config: VideoEncoderConfig = {
-                    codec: "avc1.420028",
-                    width: canvas.width,
-                    height: canvas.height,
+                    // High profile, level 4. Could switch to lower level if latency seems to be an issue
+                    codec: "avc1.640028",
+                    width: roundedWidth,
+                    height: roundedHeight,
+                    framerate: this.frameRate,
+                    bitrate: 1e7,
+                    bitrateMode: "constant",
+                    latencyMode: "realtime",
                 };
                 const { supported, config: supportedConfig } =
                     await VideoEncoder.isConfigSupported(config);


### PR DESCRIPTION
The `VideoEncoder` avc codecs are failing unless we provide them only even numbers for width and height.

In debugging this I explored the codecs a bit and tweaked a few things, aiming for high quality output with reasonable file sizes:
- using a High profile, level 4 AVC codec: this means better compression features and high resolutions
- defining a high bitrate (relative to codecs capability) but letting bitrateMode be variable to keep file sizes down
- real time latencyMode since we are capturing stream, also keeps sizes down