### PR TITLE
onRecordedMovies should be optional

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
   "trailingComma": "es5",
-  "tabWidth": 4,
-  "jsxBracketSameLine": true
+  "tabWidth": 4
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "trailingComma": "es5",
-  "tabWidth": 4
+  "tabWidth": 4,
+  "jsxBracketSameLine": true
 }

--- a/examples/src/RecordMovieComponent.tsx
+++ b/examples/src/RecordMovieComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 
 interface RecordMovieComponentProps {
     isRecording: boolean;
@@ -10,7 +10,7 @@ const RecordMovieComponent = ({
     isRecording,
     setIsRecording,
     isRecordingEnabled,
-}: RecordMovieComponentProps) => {
+}: RecordMovieComponentProps): JSX.Element => {
     // recording time measured in seconds
     let [recordingTimeElapsed, setRecordingTimeElapsed] = useState<number>(0);
     let [outputStatus, setOutputStatus] = useState<string>("");
@@ -47,26 +47,21 @@ const RecordMovieComponent = ({
                 onClick={startRecording}
                 disabled={
                     !isRecordingEnabled || isRecording || !browserSupported
-                }
-            >
+                }>
                 Start Recording
             </button>
             <button
                 onClick={stopRecording}
                 disabled={
                     !isRecordingEnabled || !isRecording || !browserSupported
-                }
-            >
+                }>
                 Stop Recording
             </button>
             <div>{isRecording ? "Recording..." : ""}</div>
             <div>
-                {" "}
-                {!browserSupported
-                    ? "Browser does not support recording"
-                    : ""}{" "}
+                {!browserSupported ? "Browser does not support recording" : ""}
                 {!isRecordingEnabled
-                    ? "Recording is not enabled, provide a callback to enable feature"
+                    ? "Recording is not enled, provide a callback to enable feature"
                     : ""}
             </div>
             <div>

--- a/examples/src/RecordMovieComponent.tsx
+++ b/examples/src/RecordMovieComponent.tsx
@@ -3,11 +3,13 @@ import React, { useState, useEffect, useRef } from "react";
 interface RecordMovieComponentProps {
     isRecording: boolean;
     setIsRecording: (isRecording: boolean) => void;
+    isRecordingEnabled: boolean;
 }
 
 const RecordMovieComponent = ({
     isRecording,
     setIsRecording,
+    isRecordingEnabled,
 }: RecordMovieComponentProps) => {
     // recording time measured in seconds
     let [recordingTimeElapsed, setRecordingTimeElapsed] = useState<number>(0);
@@ -43,18 +45,30 @@ const RecordMovieComponent = ({
         <div>
             <button
                 onClick={startRecording}
-                disabled={isRecording || !browserSupported}
+                disabled={
+                    !isRecordingEnabled || isRecording || !browserSupported
+                }
             >
                 Start Recording
             </button>
             <button
                 onClick={stopRecording}
-                disabled={!isRecording || !browserSupported}
+                disabled={
+                    !isRecordingEnabled || !isRecording || !browserSupported
+                }
             >
                 Stop Recording
-                </button>
+            </button>
             <div>{isRecording ? "Recording..." : ""}</div>
-            <div> {!browserSupported ? "Browser does not support recording" : ""} </div>
+            <div>
+                {" "}
+                {!browserSupported
+                    ? "Browser does not support recording"
+                    : ""}{" "}
+                {!isRecordingEnabled
+                    ? "Recording is not enabled, provide a callback to enable feature"
+                    : ""}
+            </div>
             <div>
                 {isRecording
                     ? "Recording duration:  " +

--- a/examples/src/RecordMovieComponent.tsx
+++ b/examples/src/RecordMovieComponent.tsx
@@ -3,17 +3,15 @@ import React, { useState, useEffect } from "react";
 interface RecordMovieComponentProps {
     isRecording: boolean;
     setIsRecording: (isRecording: boolean) => void;
-    isRecordingEnabled: boolean;
 }
 
 const RecordMovieComponent = ({
     isRecording,
     setIsRecording,
-    isRecordingEnabled,
 }: RecordMovieComponentProps): JSX.Element => {
     // recording time measured in seconds
-    let [recordingTimeElapsed, setRecordingTimeElapsed] = useState<number>(0);
-    let [outputStatus, setOutputStatus] = useState<string>("");
+    const [recordingTimeElapsed, setRecordingTimeElapsed] = useState<number>(0);
+    const [outputStatus, setOutputStatus] = useState<string>("");
 
     const browserSupported = "VideoEncoder" in window;
 
@@ -45,24 +43,17 @@ const RecordMovieComponent = ({
         <div>
             <button
                 onClick={startRecording}
-                disabled={
-                    !isRecordingEnabled || isRecording || !browserSupported
-                }>
+                disabled={isRecording || !browserSupported}>
                 Start Recording
             </button>
             <button
                 onClick={stopRecording}
-                disabled={
-                    !isRecordingEnabled || !isRecording || !browserSupported
-                }>
+                disabled={!isRecording || !browserSupported}>
                 Stop Recording
             </button>
             <div>{isRecording ? "Recording..." : ""}</div>
             <div>
                 {!browserSupported ? "Browser does not support recording" : ""}
-                {!isRecordingEnabled
-                    ? "Recording is not enled, provide a callback to enable feature"
-                    : ""}
             </div>
             <div>
                 {isRecording

--- a/examples/src/RecordMovieComponent.tsx
+++ b/examples/src/RecordMovieComponent.tsx
@@ -1,15 +1,16 @@
 import React, { useState, useEffect } from "react";
 
 interface RecordMovieComponentProps {
-    isRecording: boolean;
-    setIsRecording: (isRecording: boolean) => void;
+    startRecordingHandler: () => void;
+    stopRecordingHandler: () => void;
 }
 
 const RecordMovieComponent = ({
-    isRecording,
-    setIsRecording,
+    startRecordingHandler,
+    stopRecordingHandler,
 }: RecordMovieComponentProps): JSX.Element => {
     // recording time measured in seconds
+    const [isRecording, setIsRecording] = useState<boolean>(false);
     const [recordingTimeElapsed, setRecordingTimeElapsed] = useState<number>(0);
     const [outputStatus, setOutputStatus] = useState<string>("");
 
@@ -31,24 +32,28 @@ const RecordMovieComponent = ({
     const startRecording = async () => {
         setOutputStatus("");
         setIsRecording(true);
+        startRecordingHandler();
     };
 
     const stopRecording = () => {
         setOutputStatus("Recording complete");
         setIsRecording(false);
         setRecordingTimeElapsed(0);
+        stopRecordingHandler();
     };
 
     return (
         <div>
             <button
                 onClick={startRecording}
-                disabled={isRecording || !browserSupported}>
+                disabled={isRecording || !browserSupported}
+            >
                 Start Recording
             </button>
             <button
                 onClick={stopRecording}
-                disabled={!isRecording || !browserSupported}>
+                disabled={!isRecording || !browserSupported}
+            >
                 Stop Recording
             </button>
             <div>{isRecording ? "Recording..." : ""}</div>

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -106,6 +106,7 @@ interface ViewerState {
     } | null;
     serverHealthy: boolean;
     isRecording: boolean;
+    isRecordingEnabled: boolean;
     trajectoryTitle: string;
 }
 
@@ -167,6 +168,7 @@ const initialState: ViewerState = {
     simulariumFile: null,
     serverHealthy: false,
     isRecording: false,
+    isRecordingEnabled: true,
     trajectoryTitle: "",
 };
 
@@ -712,6 +714,10 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         return false;
     };
 
+    public setRecordingEnabled = (value: boolean): void => {
+        this.setState({ isRecordingEnabled: value });
+    }
+
     public render(): JSX.Element {
         if (this.state.filePending) {
             const fileType = this.state.filePending.type;
@@ -981,7 +987,10 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     updateAgentColorArray={this.updateAgentColorArray}
                     setColorSelectionInfo={this.setColorSelectionInfo}
                 />
-                {this.isRecordingEnabledInViewer() && (
+                <button onClick={() => this.setRecordingEnabled(!this.state.isRecordingEnabled)}>
+                    {this.state.isRecordingEnabled ? "Disable" : "Enable"} Recording
+                </button>
+                {this.state.isRecordingEnabled && (
                     <RecordMovieComponent
                         isRecording={this.state.isRecording}
                         setIsRecording={this.setIsRecording}
@@ -1006,7 +1015,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                             this
                         )}
                         recording={this.state.isRecording}
-                        onRecordedMovie={this.onRecordedMovie}
+                        onRecordedMovie={this.state.isRecordingEnabled ? this.onRecordedMovie : undefined}
                         loadInitialData={true}
                         agentColors={this.state.agentColors}
                         showPaths={this.state.showPaths}

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -981,11 +981,12 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     updateAgentColorArray={this.updateAgentColorArray}
                     setColorSelectionInfo={this.setColorSelectionInfo}
                 />
-                <RecordMovieComponent
-                    isRecording={this.state.isRecording}
-                    setIsRecording={this.setIsRecording}
-                    isRecordingEnabled={this.isRecordingEnabledInViewer()}
-                />
+                {this.isRecordingEnabledInViewer() && (
+                    <RecordMovieComponent
+                        isRecording={this.state.isRecording}
+                        setIsRecording={this.setIsRecording}
+                    />
+                )}
                 <div className="viewer-container">
                     <SimulariumViewer
                         ref={this.viewerRef}

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -21,8 +21,8 @@ import SimulariumViewer, {
 /**
  * NOTE: if you are debugging an import/build issue
  * on the front end, you may need to switch to the
- * following import statements to reproduce the issue 
- * here. 
+ * following import statements to reproduce the issue
+ * here.
  */
 // import SimulariumViewer, {
 //     SimulariumController,
@@ -105,7 +105,6 @@ interface ViewerState {
         data: ISimulariumFile | null;
     } | null;
     serverHealthy: boolean;
-    isRecording: boolean;
     isRecordingEnabled: boolean;
     trajectoryTitle: string;
 }
@@ -167,7 +166,6 @@ const initialState: ViewerState = {
     filePending: null,
     simulariumFile: null,
     serverHealthy: false,
-    isRecording: false,
     isRecordingEnabled: true,
     trajectoryTitle: "",
 };
@@ -281,7 +279,8 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                         } else {
                             return loadSimulariumFile(element);
                         }
-                    })
+                    }
+                )
             )
                 .then((parsedFiles: (ISimulariumFile | string)[]) => {
                     const simulariumFile = parsedFiles[
@@ -680,7 +679,9 @@ class Viewer extends React.Component<InputParams, ViewerState> {
 
     ////// DOWNLOAD MOVIES PROPS AND FUNCTIONS //////
     public getRecordedMovieTitle = (): string => {
-        return this.state.trajectoryTitle ? this.state.trajectoryTitle : "simularium";
+        return this.state.trajectoryTitle
+            ? this.state.trajectoryTitle
+            : "simularium";
     };
 
     public downloadMovie = (videoBlob: Blob, title?: string) => {
@@ -700,13 +701,9 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         this.downloadMovie(videoBlob, title);
     };
 
-    public setIsRecording = (isRecording: boolean) => {
-        this.setState({ isRecording: isRecording });
-    };
-
     public setRecordingEnabled = (value: boolean): void => {
         this.setState({ isRecordingEnabled: value });
-    }
+    };
 
     public render(): JSX.Element {
         if (this.state.filePending) {
@@ -977,13 +974,22 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     updateAgentColorArray={this.updateAgentColorArray}
                     setColorSelectionInfo={this.setColorSelectionInfo}
                 />
-                <button onClick={() => this.setRecordingEnabled(!this.state.isRecordingEnabled)}>
-                    {this.state.isRecordingEnabled ? "Disable" : "Enable"} Recording
+                <button
+                    onClick={() =>
+                        this.setRecordingEnabled(!this.state.isRecordingEnabled)
+                    }
+                >
+                    {this.state.isRecordingEnabled ? "Disable" : "Enable"}{" "}
+                    Recording
                 </button>
                 {this.state.isRecordingEnabled && (
                     <RecordMovieComponent
-                        isRecording={this.state.isRecording}
-                        setIsRecording={this.setIsRecording}
+                        startRecordingHandler={
+                            simulariumController.startRecording
+                        }
+                        stopRecordingHandler={
+                            simulariumController.stopRecording
+                        }
                     />
                 )}
                 <div className="viewer-container">
@@ -1004,8 +1010,11 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                         onUIDisplayDataChanged={this.handleUIDisplayData.bind(
                             this
                         )}
-                        recording={this.state.isRecording}
-                        onRecordedMovie={this.state.isRecordingEnabled ? this.onRecordedMovie : undefined}
+                        onRecordedMovie={
+                            this.state.isRecordingEnabled
+                                ? this.onRecordedMovie
+                                : undefined
+                        }
                         loadInitialData={true}
                         agentColors={this.state.agentColors}
                         showPaths={this.state.showPaths}

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -279,7 +279,8 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                         } else {
                             return loadSimulariumFile(element);
                         }
-                    })
+                    }
+                )
             )
                 .then((parsedFiles: (ISimulariumFile | string)[]) => {
                     const simulariumFile = parsedFiles[
@@ -678,7 +679,9 @@ class Viewer extends React.Component<InputParams, ViewerState> {
 
     ////// DOWNLOAD MOVIES PROPS AND FUNCTIONS //////
     public getRecordedMovieTitle = (): string => {
-        return this.state.trajectoryTitle ? this.state.trajectoryTitle : "simularium";
+        return this.state.trajectoryTitle
+            ? this.state.trajectoryTitle
+            : "simularium";
     };
 
     public downloadMovie = (videoBlob: Blob, title?: string) => {
@@ -700,6 +703,16 @@ class Viewer extends React.Component<InputParams, ViewerState> {
 
     public setIsRecording = (isRecording: boolean) => {
         this.setState({ isRecording: isRecording });
+    };
+
+    // Remove the Viewer's onRecordedMovie prop assigment to disable feature
+    private isRecordingEnabledInViewer = () => {
+        const viewerElement = this.viewerRef.current;
+        if (viewerElement) {
+            const viewerProps = viewerElement.props;
+            return !!viewerProps.onRecordedMovie;
+        }
+        return false;
     };
 
     public render(): JSX.Element {
@@ -974,6 +987,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 <RecordMovieComponent
                     isRecording={this.state.isRecording}
                     setIsRecording={this.setIsRecording}
+                    isRecordingEnabled={this.isRecordingEnabledInViewer()}
                 />
                 <div className="viewer-container">
                     <SimulariumViewer

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -279,8 +279,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                         } else {
                             return loadSimulariumFile(element);
                         }
-                    }
-                )
+                    })
             )
                 .then((parsedFiles: (ISimulariumFile | string)[]) => {
                     const simulariumFile = parsedFiles[
@@ -679,9 +678,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
 
     ////// DOWNLOAD MOVIES PROPS AND FUNCTIONS //////
     public getRecordedMovieTitle = (): string => {
-        return this.state.trajectoryTitle
-            ? this.state.trajectoryTitle
-            : "simularium";
+        return this.state.trajectoryTitle ? this.state.trajectoryTitle : "simularium";
     };
 
     public downloadMovie = (videoBlob: Blob, title?: string) => {

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -704,16 +704,6 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         this.setState({ isRecording: isRecording });
     };
 
-    // Remove the Viewer's onRecordedMovie prop assigment to disable feature
-    private isRecordingEnabledInViewer = () => {
-        const viewerElement = this.viewerRef.current;
-        if (viewerElement) {
-            const viewerProps = viewerElement.props;
-            return !!viewerProps.onRecordedMovie;
-        }
-        return false;
-    };
-
     public setRecordingEnabled = (value: boolean): void => {
         this.setState({ isRecordingEnabled: value });
     }

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -52,6 +52,8 @@ export default class SimulariumController {
     public tickIntervalLength: number;
     public handleTrajectoryInfo: (TrajectoryFileInfo) => void;
     public postConnect: () => void;
+    public startRecording: () => void;
+    public stopRecording: () => void;
     public onError?: (error: FrontEndError) => void;
 
     private networkEnabled: boolean;
@@ -63,6 +65,8 @@ export default class SimulariumController {
         this.visData = new VisData();
         this.tickIntervalLength = 0; // Will be overwritten when a trajectory is loaded
         this.postConnect = () => noop;
+        this.startRecording = () => noop;
+        this.stopRecording = () => noop;
 
         this.handleTrajectoryInfo = (/*msg: TrajectoryFileInfo*/) => noop;
         this.onError = (/*errorMessage*/) => noop;

--- a/src/simularium/FrameRecorder.ts
+++ b/src/simularium/FrameRecorder.ts
@@ -35,6 +35,9 @@ export class FrameRecorder {
     }
 
     private async setup(): Promise<void> {
+        if (!this.supportedBrowser) {
+            throw new Error("Browser does not support video recording");
+        }
         const canvas = this.getCanvas();
         if (canvas) {
             const evenWidth = Math.ceil(canvas.width / 2) * 2;
@@ -88,18 +91,21 @@ export class FrameRecorder {
     }
 
     public async start(): Promise<void> {
-        try {
-            await this.setup();
-            this.isRecording = true;
-        } catch (e) {
-            console.log("setup failed", e);
-            return;
-        }
+        if (!this.isRecording)
+            try {
+                await this.setup();
+                this.isRecording = true;
+            } catch (e) {
+                console.log("setup failed", e);
+                return;
+            }
     }
 
     public async stop(): Promise<void> {
-        this.isRecording = false;
-        await this.onCompletedRecording();
+        if (this.isRecording) {
+            this.isRecording = false;
+            await this.onCompletedRecording();
+        }
     }
 
     public onFrame(): void {

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -45,7 +45,7 @@ type ViewportProps = {
     onError?: (error: FrontEndError) => void;
     lockedCamera?: boolean;
     recording?: boolean;
-    onRecordedMovie?: (blob: Blob) => void; // provide a callback to enable recording feature
+    onRecordedMovie?: (blob: Blob) => void; // provide a callback to enable recording
 } & Partial<DefaultProps>;
 
 const defaultProps = {


### PR DESCRIPTION
Review Time
=======
_Small_

Problem
=======
Closes #368 
`onRecordedMovies` should be optional for implementations where movie recording is not desired.

_Note: snuck in a commit in the prettier config to prevent {" "} < ---- those from appearing, I think it works to prevent them showing up when not needed, can add to sim-website too_

Solution
========
Made the `recording` and `onRecordedMovie` props optional. If `onRecordedMovie` is undefined, set `recorder` to null, and adjusted references to account for that. 

When a callback is provided, the feature will be enabled, and if the prop is undefined then no `FrameRecorder` functions should be called even if `recording` is set to `true`.

Added a function in test-bed to check if recording is enabled or not and display a message if so.

To test you can comment out the prop assigment:
 `// onRecordedMovie={this.onRecordedMovie}` Recording buttons should be disabled but viewer should work.
 
 For a further test provide a true value to `isRecordingEnabled`
 ```
                 <RecordMovieComponent
                    isRecording={this.state.isRecording}
                    setIsRecording={this.setIsRecording}
                    isRecordingEnabled={true}
                />
 ```
 
 Buttons will be clickable but should have no effect.

* New feature (non-breaking change which adds functionality)
