### PR TITLE
reset colorsData to default before mapping agent colors when loading …

### DIFF
--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -215,7 +215,7 @@ class Viewport extends React.Component<
         }
         const uiDisplayData = this.selectionInterface.getUIDisplayData();
         onTrajectoryFileInfoChanged(trajectoryFileInfo);
-        this.visGeometry.colorHandler.clearColorMapping();
+        this.visGeometry.colorHandler.resetDefaultColorsData(agentColors);
 
         const updatedColors = this.selectionInterface.setInitialAgentColors(
             uiDisplayData,

--- a/src/visGeometry/ColorHandler.ts
+++ b/src/visGeometry/ColorHandler.ts
@@ -196,6 +196,11 @@ class ColorHandler {
         const color = this.getColorById(colorId);
         return { color, colorId };
     }
+
+    public resetDefaultColorsData(defaultColors: (number | string)[]): void {
+        this.clearColorMapping();
+        this.updateColorArray(defaultColors);
+    }
 }
 
 export default ColorHandler;


### PR DESCRIPTION
Time Estimate or Size
=======
_Xsmall_

Problem
=======
Colors are wrong when loading consecutive local files. [This issue.](https://github.com/simularium/simularium-website/issues/490)

Solution
========
We were clearing the colorMapping when loading a new trajectory, but the `colorsData` array was retaining changes if the previous trajectory had added non-default colors, we now reset it to the default agent colors when loading new trajectories.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Download the two trajectories @blairlyons linked in the issue and try loading them back to back, on main the second trajectory should show an incorrect (usually yellow) color. On this branch they should be the correct reds and grays you can confirm from the uiDisplayData.

Screenshots (optional):
-----------------------
<img width="218" alt="Screenshot 2024-04-10 at 9 34 36 AM" src="https://github.com/simularium/simularium-viewer/assets/24981838/307f67de-cd36-48d7-ab4e-44400e5389bf">
<img width="181" alt="Screenshot 2024-04-10 at 9 34 26 AM" src="https://github.com/simularium/simularium-viewer/assets/24981838/9f4cc384-ab57-4b68-b33f-4d7f614fc51f">
