### PR TITLE
Feature/turn controls back on

### DIFF
--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -310,6 +310,7 @@ class Viewport extends React.Component<
             showPaths,
             showBounds,
             selectionStateInfo,
+            lockedCamera,
         } = this.props;
 
         if (selectionStateInfo) {
@@ -368,6 +369,12 @@ class Viewport extends React.Component<
         }
         if (prevProps.height !== height || prevProps.width !== width) {
             this.visGeometry.resize(width, height);
+        }
+        if (prevProps.lockedCamera !== lockedCamera) {
+            this.visGeometry.setCanvasOnTheDom(
+                this.vdomRef.current,
+                lockedCamera
+            );
         }
         if (prevState.showRenderParamsGUI !== this.state.showRenderParamsGUI) {
             if (this.state.showRenderParamsGUI) {
@@ -547,8 +554,8 @@ class Viewport extends React.Component<
             }
             if (!this.props.lockedCamera) {
                 this.visGeometry.setFollowObject(intersectedObject);
+                this.visGeometry.addPathForAgent(intersectedObject);
             }
-            this.visGeometry.addPathForAgent(intersectedObject);
         } else {
             if (oldFollowObject !== NO_AGENT) {
                 this.visGeometry.removePathForAgent(oldFollowObject);

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -371,10 +371,7 @@ class Viewport extends React.Component<
             this.visGeometry.resize(width, height);
         }
         if (prevProps.lockedCamera !== lockedCamera) {
-            this.visGeometry.setCanvasOnTheDom(
-                this.vdomRef.current,
-                lockedCamera
-            );
+            this.visGeometry.toggleControls(lockedCamera);
         }
         if (prevState.showRenderParamsGUI !== this.state.showRenderParamsGUI) {
             if (this.state.showRenderParamsGUI) {

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -882,6 +882,14 @@ class VisGeometry {
         );
     }
 
+    public toggleControls(lockedCamera: boolean): void {
+        if (lockedCamera) {
+            this.disableControls();
+        } else {
+            this.enableControls();
+        }
+    }
+
     public disableControls(): void {
         this.controls.enabled = false;
     }


### PR DESCRIPTION
Time Estimate or Size
=======
xsmall

Problem
=======
for the education module: I originally thought I would use a separate instance of the viewer when changing to 3d trajectories, but the setup I have is just switching files so I need to be able to turn the controls on and off 

Solution
========
added a toggle function that gets called when the prop is changed 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
