### PR TITLE
don't give a parent a color of the children have different colors

### DIFF
--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -1,4 +1,4 @@
-import { filter, find, uniq } from "lodash";
+import { filter, find, map, uniq } from "lodash";
 import { EncodedTypeMapping } from "./types";
 import { convertColorNumberToString } from "../visGeometry/ColorHandler";
 
@@ -230,6 +230,18 @@ class SelectionInterface {
         this.entries = new Map<string, DecodedTypeEntry>();
     }
 
+    public getParentColor(name: string): string {
+        // wrapping in filter removes undefined values
+        const listOfUniqChildrenColors = filter(
+            uniq(map(this.entries[name], "color"))
+        );
+        const color =
+            listOfUniqChildrenColors.length === 1
+                ? listOfUniqChildrenColors[0]
+                : "";
+        return color;
+    }
+
     public getUIDisplayData(): UIDisplayData {
         return Object.keys(this.entries).map((name) => {
             const displayStates: DisplayStateEntry[] = [];
@@ -260,7 +272,9 @@ class SelectionInterface {
                     displayStates.push(displayState);
                 });
             });
-            const color = this.entries[name][0].color || "";
+
+            const color = this.getParentColor(name);
+
             return {
                 name,
                 displayStates,

--- a/src/test/SelectionInterface.test.ts
+++ b/src/test/SelectionInterface.test.ts
@@ -340,6 +340,15 @@ describe("SelectionInterface module", () => {
         });
     });
 
+    describe("getParentColor", () => {
+        test("it returns an empty string if there are no colors set", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const parentColor = si.getParentColor("E");
+            expect(parentColor).toEqual("");
+        });
+    });
+
     describe("getUIDisplayData", () => {
         test("Doesn't crash", () => {
             const si = new SelectionInterface();


### PR DESCRIPTION
Time Estimate or Size
=======
xsmall

Problem
=======
closes https://github.com/simularium/simularium-website/issues/505

Solution
========
The parent was getting assigned a color of its first child, so the UIData sent to the website gave the parent a color, even though it wasn't displayed it was keeping the children from being open 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. go to https://staging.simularium.allencell.org/viewer?trajUrl=https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/binding-affinity_antibodies.simularium
2. The Antibody parent is closed 
3. install this version of the viewer in the `simularium-website` locally
4. go to http://localhost:9001/viewer?trajUrl=https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/binding-affinity_antibodies.simularium
5. it's fixed 

Screenshots (optional):
-----------------------
without this change, Antibody parent has been assigned the color of it's first child 
<img width="497" alt="Screenshot 2024-05-03 at 11 50 11 AM" src="https://github.com/simularium/simularium-viewer/assets/5170636/98c607ce-2c0e-484b-8172-9842d769e63d">


with these changes: parent doesn't have a color
<img width="248" alt="Screenshot 2024-05-03 at 11 43 59 AM" src="https://github.com/simularium/simularium-viewer/assets/5170636/3258d0b4-7651-43e2-a5a8-de452b3bd56f">
