### PR TITLE
Feature/change to converted file

### DIFF
--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -394,7 +394,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
     public convertFile(obj: Record<string, any>, fileType: TrajectoryType) {
         const fileName = uuidv4() + ".simularium";
         simulariumController
-            .convertAndLoadTrajectory(this.netConnectionSettings, obj, fileType, fileName)
+            .convertTrajectory(this.netConnectionSettings, obj, fileType, fileName)
             .then(() => {
                 this.clearPendingFile();
             })

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { isEqual, findIndex, map, reduce } from "lodash";
+import { v4 as uuidv4 } from "uuid";
 
 import type {
     ISimulariumFile,
@@ -391,10 +392,18 @@ class Viewer extends React.Component<InputParams, ViewerState> {
     }
 
     public convertFile(obj: Record<string, any>, fileType: TrajectoryType) {
+        const fileName = uuidv4() + ".simularium";
         simulariumController
-            .convertAndLoadTrajectory(this.netConnectionSettings, obj, fileType)
+            .convertAndLoadTrajectory(this.netConnectionSettings, obj, fileType, fileName)
             .then(() => {
                 this.clearPendingFile();
+            })
+            .then(() => {
+                simulariumController.changeFile(
+                    { netConnectionSettings: this.netConnectionSettings, },
+                    fileName,
+                    true,
+                )
             })
             .catch((err) => {
                 console.error(err);

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -197,8 +197,8 @@ class Viewer extends React.Component<InputParams, ViewerState> {
             };
         } else if (props.useOctopus) {
             this.netConnectionSettings = {
-                serverIp: "18.223.108.15",
-                serverPort: 8765,
+                serverIp: "staging-simularium-ecs.allencell.org",
+                serverPort: 443,
                 useOctopus: true,
                 secureConnection: true,
             };

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -351,7 +351,7 @@ export default class SimulariumController {
         connectionParams: SimulatorConnectionParams,
         // TODO: push newFileName into connectionParams
         newFileName: string,
-        keepRemoteConnection: boolean = false
+        keepRemoteConnection = false
     ): Promise<FileReturn> {
         this.isFileChanging = true;
         this.playBackFile = newFileName;

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -116,8 +116,7 @@ export default class SimulariumController {
         this.reOrientCamera = this.reOrientCamera.bind(this);
         this.setPanningMode = this.setPanningMode.bind(this);
         this.setFocusMode = this.setFocusMode.bind(this);
-        this.convertAndLoadTrajectory =
-            this.convertAndLoadTrajectory.bind(this);
+        this.convertTrajectory = this.convertTrajectory.bind(this);
         this.setCameraType = this.setCameraType.bind(this);
     }
 
@@ -231,7 +230,7 @@ export default class SimulariumController {
         }
     }
 
-    public convertAndLoadTrajectory(
+    public convertTrajectory(
         netConnectionConfig: NetConnectionParams,
         dataToConvert: Record<string, unknown>,
         fileType: TrajectoryType,

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -251,13 +251,16 @@ export default class SimulariumController {
             return Promise.reject(e);
         }
 
-        return this.simulator
-            .convertTrajectory(dataToConvert, fileType, providedFileName)
-            .then(() => {
-                if (this.simulator) {
-                    this.simulator.requestSingleFrame(0);
-                }
-            });
+        return this.simulator.convertTrajectory(
+            dataToConvert,
+            fileType,
+            providedFileName
+        );
+        // .then(() => {
+        //     if (this.simulator) {
+        //         this.simulator.requestSingleFrame(0);
+        //     }
+        // });
     }
 
     public pause(): void {

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -415,12 +415,6 @@ export default class SimulariumController {
         });
     }
 
-    // converted files can assume the simulator connection has been made
-    // during the autoconversion process, except for removing the simulatorConnection code
-    // the function repeats the above function, but may be useful to have separated out
-    // as we debug further tweaks needed to receive converted files from Octopus
-    // if its stays this similar we could refactor changeFile above to account
-    // for the case of a converted file and remove this function.
     public changeToConvertedFile(newFileName: string): Promise<FileReturn> {
         this.isFileChanging = true;
         this.playBackFile = newFileName;

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -256,11 +256,6 @@ export default class SimulariumController {
             fileType,
             providedFileName
         );
-        // .then(() => {
-        //     if (this.simulator) {
-        //         this.simulator.requestSingleFrame(0);
-        //     }
-        // });
     }
 
     public pause(): void {

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -418,11 +418,12 @@ export class RemoteSimulator implements ISimulator {
     // Start autoconversion and roll right into the simulation
     public convertTrajectory(
         dataToConvert: Record<string, unknown>,
-        fileType: TrajectoryType
+        fileType: TrajectoryType,
+        providedFileName?: string
     ): Promise<void> {
         return this.connectToRemoteServer()
             .then(() => {
-                this.sendTrajectory(dataToConvert, fileType);
+                this.sendTrajectory(dataToConvert, fileType, providedFileName);
             })
             .catch((e) => {
                 throw new FrontEndError(e.message, ErrorLevel.ERROR);
@@ -431,10 +432,15 @@ export class RemoteSimulator implements ISimulator {
 
     public sendTrajectory(
         dataToConvert: Record<string, unknown>,
-        fileType: TrajectoryType
+        fileType: TrajectoryType,
+        providedFileName?: string
     ): void {
-        // Generate random file name for converted file to be stored on the server
-        const fileName = uuidv4() + ".simularium";
+        // Check for provided file name, and if none provided
+        // generate random file name for converted file to be stored on the server
+        const fileName =
+            providedFileName !== undefined
+                ? providedFileName
+                : uuidv4() + ".simularium";
         this.lastRequestedFile = fileName;
         this.webSocketClient.sendWebSocketRequest(
             {


### PR DESCRIPTION
website branch `fix/conversion-filename-bug` points at these changes to receive file that results from autoconversion

Time Estimate or Size
=======
small-ish

Problem
=======
The handling of autoconverted files was built in the viewer with the example viewer in mind, but now that we're integrating with the website repo, we need to make some minor changes to the viewer. 

The way autoconverted files are currently handled in the viewer is that the viewer requests a file to be converted and immediately requests frame 0. However, in the website, we want to clear any previous trajectory in between these two steps, allowing users to resume interacting with the previous simulation if they cancel the autoconversion request before octopus has replied with the converted data.


Solution
========
- change SimulariumController's `convertAndLoadTrajectory()` to `convertTrajectory()`, and have that only handle sending the conversion request. The clearing of any previous trajectory and loading of frame zero can be done after, using `changeFile()`
- update `changeFile()` to include the option to not create a new remote simulator instance. Overall, if `this.simulator` is a remote simulator and the connectionParams indicate that the newly requested file also uses a remote simulator, we don't need to create a fresh remote simulator instance, we can keep using the existing one, but we don't. For non-autoconversion simulations, creating a fresh instance doesn't cause any issues, so it doesn't matter. For autoconversion, we will have already created a remote simulator instance for requesting the conversion, and we don't want to miss any responses from that by creating a new instance with a new websocket connection, so we need to skip creating a simulator. Right now, I'm only skipping this step for this autoconversion case, although we could expand and use this across remote simulator cases in the future
- allow the website to pass in it's own file name to be used internally for the autoconverted file, since we're generating that in the viewer anyways
- update the example viewer autoconversion form to use these new / updated methods
- point to the new octopus ecs staging instance, instead of the trial ec2 instance's IP address

with @ascibisz 

## Type of change

* Bug fix (non-breaking change which fixes an issue)

