### PR TITLE
Fix/no firstframetime

### DIFF
--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -413,9 +413,6 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         const simulariumFile = fileName.includes(".simularium")
             ? trajectoryFile
             : null;
-        // if (!fileName.includes(".simularium")) {
-        //     return new
-        // }
         this.setState({ initialPlay: true})
         return simulariumController
             .handleFileChange(simulariumFile, fileName, geoAssets)

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -107,6 +107,8 @@ interface ViewerState {
     serverHealthy: boolean;
     isRecordingEnabled: boolean;
     trajectoryTitle: string;
+    initialPlay: boolean;
+    firstFrameTime: number;
 }
 
 interface BaseType {
@@ -168,6 +170,8 @@ const initialState: ViewerState = {
     serverHealthy: false,
     isRecordingEnabled: true,
     trajectoryTitle: "",
+    initialPlay: true,
+    firstFrameTime: 0,
 };
 
 class Viewer extends React.Component<InputParams, ViewerState> {
@@ -412,6 +416,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         // if (!fileName.includes(".simularium")) {
         //     return new
         // }
+        this.setState({ initialPlay: true})
         return simulariumController
             .handleFileChange(simulariumFile, fileName, geoAssets)
             .catch(console.log);
@@ -424,6 +429,9 @@ class Viewer extends React.Component<InputParams, ViewerState> {
     public handleTimeChange(timeData): void {
         currentFrame = timeData.frameNumber;
         currentTime = timeData.time;
+        if (this.state.initialPlay) {
+            this.setState({ initialPlay: false, firstFrameTime: currentTime });
+        }
         this.setState({ currentFrame, currentTime });
         if (this.state.pauseOn === currentFrame) {
             simulariumController.pause();
@@ -806,7 +814,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 <input
                     name="slider"
                     type="range"
-                    min={0}
+                    min={this.state.firstFrameTime}
                     step={this.state.timeStep}
                     value={this.state.currentTime}
                     max={this.state.totalDuration}

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -287,23 +287,7 @@ export default class SimulariumController {
                 // else reset the local cache,
                 //  and play remotely from the desired simulation time
                 this.visData.clearCache();
-
-                // Instead of requesting from the backend the `time` passed into this
-                // function, we request (time - firstFrameTime) because the backend
-                // currently assumes the first frame of every trajectory is at time 0.
-                //
-                // TODO: Long term, we should decide on a better way to deal with this
-                // assumption: remove assumption from backend, perform this normalization
-                // in simulariumio, or something else? One way might be to require making
-                // firstFrameTime a part of TrajectoryFileInfo.
-                let firstFrameTime = this.visData.firstFrameTime;
-                if (firstFrameTime === null) {
-                    console.error(
-                        "VisData does not contain firstFrameTime, defaulting to 0"
-                    );
-                    firstFrameTime = 0;
-                }
-                this.simulator.gotoRemoteSimulationTime(time - firstFrameTime);
+                this.simulator.gotoRemoteSimulationTime(time);
             }
         }
     }

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -33,7 +33,6 @@ class VisData {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private _dragAndDropFileInfo: TrajectoryFileInfo | null;
 
-    public firstFrameTime: number | null;
     public timeStepSize: number;
 
     private static parseOneBinaryFrame(data: ArrayBuffer): ParsedBundle {
@@ -261,7 +260,6 @@ class VisData {
         }
         this.frameCache = [];
         this.frameDataCache = [];
-        this.firstFrameTime = null;
         this.cacheFrame = -1;
         this._dragAndDropFileInfo = null;
         this.frameToWaitFor = 0;
@@ -365,7 +363,6 @@ class VisData {
 
     public clearForNewTrajectory(): void {
         this.clearCache();
-        this.firstFrameTime = null;
     }
 
     public cancelAllWorkers(): void {
@@ -386,9 +383,6 @@ class VisData {
             this.frameCache,
             frames.parsedAgentDataArray
         );
-        if (this.firstFrameTime === null) {
-            this.firstFrameTime = frames.frameDataArray[0].time;
-        }
     }
 
     private parseAgentsFromVisDataMessage(msg: VisDataMessage): void {


### PR DESCRIPTION
Time Estimate or Size
=======
_small_

Problem
=======
Closes #362 

Solution
========
Recent changes to octopus and this @ascibisz [PR from yesterday](https://github.com/simularium/octopus/pull/82) seem to have mostly resolved these bugs. We don't need to subtract firstFrameTime anymore, when calling `goToRemoteSimulationTime` and so `visData.firstFrameTime` isn't being used anywhere. I just removed all reference to it. The front end gets the correct `firstFrameTime` by reading the `timeData` when the trajectory lands, we dont need to store it in the viewer.

Prior to realizing Alli had already fixed this I wrote code that I think improves on how we were storing `firstFrameTime` if we want it later, but for now I think we can just remove it

Start time of 0 was hard coded into the test bed slider. I changed it to act more like the website and get the value from `timeData` on initial play.

Steps to Verify:
----------------
1. Install viewer in website
1. Try all the playback controls for the trajectories linked in the issue without hitting play first and see if you get hung up on anything and if first frame time displays correctly.
