### PR TITLE
feat: Camera distance is now scaled to >= 90% of the screen real estate

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import { CameraSpec, PerspectiveCameraSpec } from "./simularium/types";
 
+// TODO: Position is being recomputed on the fly; consider removing these constants
 export const DEFAULT_CAMERA_Z_POSITION = 120;
 export const DEFAULT_CAMERA_SPEC_PERSPECTIVE: PerspectiveCameraSpec = {
     position: {

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -290,12 +290,13 @@ class VisGeometry {
     }
 
     /**
-     * Derive the default distance from camera to target from `cameraDefault` and the current
-     * bounding box.
-     * By default, this will scale the camera's position to keep the objects at a minimum ratio
-     * of the vertical screen real estate (~90%) or closer based on the FOV.
-     * Unless `cameraDefault` has been meaningfully changed by a call to
-     * `handleCameraData`, the view direction is calculated with `DEFAULT_CAMERA_Z_POSITION`.
+     * Derive the default distance from camera to target.
+     *
+     * By default, this will scale the camera's position to keep the object's bounding sphere at a
+     * minimum of 90% of the vertical screen real estate (~90%) or closer based on the FOV.
+     *
+     * If `cameraDefault` has been meaningfully changed by a call to `handleCameraData`,
+     * uses the `cameraDefault` and does not override the position.
      */
     private getDefaultOrbitRadius(): number {
         const { position, lookAtPosition, fovDegrees } = this.cameraDefault;
@@ -307,14 +308,13 @@ class VisGeometry {
         // If camera settings have not been provided, scale the default camera position to keep the objects at
         // a reasonable zoom level.
         if (!this.hasCustomCameraData) {
-            // Determine the maximum distance the camera should be so that the objects take up a certain fraction of the screen
-            // (e.g., minScreenRatio=0.8 means the bounding box should take up at least 80% of the screen).
+            // Determine the maximum distance the camera should be so that the object's bounding sphere
+            // takes up at least 90% of the screen.
             // This prevents bad camera starting positions from being too far from the objects on reset.
             const minScreenRatio = 0.9;
 
-            // To solve for max distance to keep minScreenRatio, determine the half-height of the bounding box at the center of
-            // the screen. Note that this is using the maximum RADIUS of the bounding box, not the Y-height. This way the whole
-            // bounding box should be in view, though this may misbehave on very long/wide/deep bounding boxes.
+            // To solve for max distance to keep minScreenRatio, determine the radius of the bounding sphere at the center of
+            // the screen.
             const centerPoint = coordsToVector(lookAtPosition);
             const maxBoundingBoxRadius = this.boundingBox.getBoundingSphere(
                 new Sphere(centerPoint)

--- a/src/visGeometry/index.ts
+++ b/src/visGeometry/index.ts
@@ -304,7 +304,8 @@ class VisGeometry {
         const minScreenRatio = 0.9;
 
         // To solve for max distance to keep minScreenRatio, determine the half-height of the bounding box at the center of
-        // the screen.
+        // the screen. Note that this is using the maximum RADIUS of the bounding box, not the Y-height. This way the whole
+        // bounding box should be in view, though this may misbehave on very long/wide/deep bounding boxes.
         const centerPoint = this.coordinateToVector3(lookAtPosition);
         const maxBoundingBoxRadius = this.boundingBox.getBoundingSphere(
             new Sphere(centerPoint)


### PR DESCRIPTION
Time Estimate or Size
=======
*Estimated size: small, 5-10 minutes*

Problem
=======
Closes #330, a bug where the camera would be zoomed too far out on reset.

Solution
========
- If camera settings are undefined, the camera's max orbit radius will be determined using its FOV and the size of the object's bounding sphere, keeping the bounding sphere at 90% of the vertical screen real estate.
- Changes `cameraDefault` to be an optional property in `TrajectoryFileInfo`, so 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. Clone the branch and build.
2. Change your local clone of the `simularium-website` repo to use your local, built version of `volume-viewer`.
3. Open the following file: `https://www.dropbox.com/scl/fi/2srfuliyjnu3sr1tlfgwf/cells_2023-10-04.simularium?rlkey=hg35vs9cwrla19eq2m0al81t4`
4. Switch between orthographic and perspective mode and reset the camera to home.
5. Go to the main page and open other simulations. They should look the same or be slightly closer to the camera than before.


Screenshots (optional):
-----------------------
| Before | After |
| --- | --- |
| ![image](https://github.com/simularium/simularium-viewer/assets/30200665/da8814d6-4f44-4893-8cc5-d24685f24beb) | ![image](https://github.com/simularium/simularium-viewer/assets/30200665/9834508e-d77e-4aa5-bb88-f5e89fdd7de3) | 
| ![image](https://github.com/simularium/simularium-viewer/assets/30200665/af3c8f38-5b62-4858-b792-4c537da3184a) | ![image](https://github.com/simularium/simularium-viewer/assets/30200665/84319b42-f698-4f73-ae83-c6868e355515) |

Unchanged:
| Before | After |
| --- | --- | 
| ![image](https://github.com/simularium/simularium-viewer/assets/30200665/3905cdff-8bcd-47e1-a125-35273e6cc56d) | ![image](https://github.com/simularium/simularium-viewer/assets/30200665/8cd07671-78bd-4a71-b95a-b873ddd0c653) |

