### PR TITLE
add cancel autoconversion action to viewer

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -423,6 +423,13 @@ export default class SimulariumController {
         }
     }
 
+    public cancelConversion(): void {
+        // Only relevant if there is an active RemoteSimulator instance
+        if (this.simulator && this.simulator instanceof RemoteSimulator) {
+            this.simulator.cancelConversion();
+        }
+    }
+
     private setupMetricsCalculator(
         config: NetConnectionParams
     ): RemoteMetricsCalculator {

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -469,4 +469,15 @@ export class RemoteSimulator implements ISimulator {
                 );
             });
     }
+
+    public cancelConversion(): void {
+        this.webSocketClient.sendWebSocketRequest(
+            {
+                msgType: NetMessageEnum.ID_CANCEL_CONVERSION,
+                fileName: this.lastRequestedFile,
+            },
+            "Cancel the requested autoconversion"
+        );
+        this.lastRequestedFile = "";
+    }
 }

--- a/src/simularium/WebsocketClient.ts
+++ b/src/simularium/WebsocketClient.ts
@@ -56,6 +56,7 @@ export const enum NetMessageEnum {
     ID_ERROR_MSG = 21,
     ID_CHECK_HEALTH_REQUEST = 22,
     ID_SERVER_HEALTHY_RESPONSE = 23,
+    ID_CANCEL_CONVERSION = 24,
     // insert new values here before LENGTH
     LENGTH,
 }


### PR DESCRIPTION
Time Estimate or Size
=======
xsmall

Problem
=======
[This Octopus PR](https://github.com/simularium/octopus/pull/88) adds a new message type for cancelling an autoconversion request. This PR adds this message type to the viewer, so that eventually we can tie this in with the website


## Type of change

* New feature (non-breaking change which adds functionality)
