### PR TITLE
Fix/remove simularium engine specific code

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This will run the example in `/examples/src/`, demonstrating the viewer's functi
 | transpileES       | run babel on `src` directory; _do not_ transpile `import/export` statements for an ES module compatible build (used by bundlers for tree-shaking) |
 | test              | run `jest`; searches for any files matching the pattern "src/\*_/_.test.js"                                                                      |
 | typeCheck         | run `tsc` in type-check only mode                                                                                                                 |
-| start             | runs an example app from `examples` for testing. Runs at `localhost:8080/public/`. Use `--octopus` to connect to octopus backend and/or `--localserver` to run backend locally. With no flags, this script will default to using remote simularium-engine as backend |
+| start             | runs an example app from `examples` for testing. Runs at `localhost:8080/public/`. Use `--localserver` to run backend locally. With no flags, this script will default to using the staging octopus server as backend |
 
 ---
 

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -138,7 +138,6 @@ interface CustomType {
 
 interface InputParams {
     localBackendServer: boolean;
-    useOctopus: boolean;
 }
 
 const simulariumController = new SimulariumController({});
@@ -197,22 +196,11 @@ class Viewer extends React.Component<InputParams, ViewerState> {
             this.netConnectionSettings = {
                 serverIp: "0.0.0.0",
                 serverPort: 8765,
-                useOctopus: props.useOctopus,
-                secureConnection: props.useOctopus,
-            };
-        } else if (props.useOctopus) {
-            this.netConnectionSettings = {
-                serverIp: "staging-simularium-ecs.allencell.org",
-                serverPort: 443,
-                useOctopus: true,
-                secureConnection: true,
             };
         } else {
             this.netConnectionSettings = {
-                serverIp: "staging-node1-agentviz-backend.cellexplore.net",
-                serverPort: 9002,
-                secureConnection: true,
-                useOctopus: false,
+                serverIp: "staging-simularium-ecs.allencell.org",
+                serverPort: 443,
             };
         }
     }

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -3,7 +3,6 @@ import { createRoot } from "react-dom/client";
 
 import Viewer from './Viewer';
 
-declare const SIMULARIUM_USE_OCTOPUS: boolean;
 declare const SIMULARIUM_USE_LOCAL_BACKEND: boolean;
 
 const container: HTMLElement | null = document.getElementById("root");
@@ -11,7 +10,6 @@ const container: HTMLElement | null = document.getElementById("root");
 const root = createRoot(container!);
 root.render(
     <Viewer
-        useOctopus={SIMULARIUM_USE_OCTOPUS}
         localBackendServer={SIMULARIUM_USE_LOCAL_BACKEND}
     />
 );

--- a/examples/webpack.dev.js
+++ b/examples/webpack.dev.js
@@ -28,7 +28,6 @@ module.exports = {
             ],
         }),
         new webpack.DefinePlugin({
-            SIMULARIUM_USE_OCTOPUS: Boolean(process.env.npm_config_octopus),
             SIMULARIUM_USE_LOCAL_BACKEND: Boolean(process.env.npm_config_localserver),
         }),
     ],

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -140,7 +140,7 @@ export default class SimulariumController {
                 this.visGeometry.geometryStore.cacheLocalAssets(geoAssets);
             }
             this.simulator.setTrajectoryDataHandler(
-                this.visData.parseAgentsFromLocalFileData.bind(this.visData)
+                this.visData.parseAgentsFromFrameData.bind(this.visData)
             );
         } else if (netConnectionConfig) {
             const webSocketClient = new WebsocketClient(

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -148,11 +148,7 @@ export default class SimulariumController {
                 this.onError
             );
             this.remoteWebsocketClient = webSocketClient;
-            this.simulator = new RemoteSimulator(
-                webSocketClient,
-                !!netConnectionConfig.useOctopus,
-                this.onError
-            );
+            this.simulator = new RemoteSimulator(webSocketClient, this.onError);
             this.simulator.setTrajectoryDataHandler(
                 this.visData.parseAgentsFromNetData.bind(this.visData)
             );

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -12,7 +12,7 @@ import { ISimulator } from "./ISimulator";
 import { TrajectoryFileInfoV2, VisDataMessage } from "./types";
 import { TrajectoryType } from "../constants";
 
-// a RemoteSimulator is a ISimulator that connects to the Octopus back end server
+// a RemoteSimulator is a ISimulator that connects to the Octopus backend server
 // and plays back a trajectory specified in the NetConnectionParams
 export class RemoteSimulator implements ISimulator {
     public webSocketClient: WebsocketClient;

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -19,8 +19,8 @@ const enum PlayBackType {
     // insert new values here before LENGTH
     LENGTH,
 }
-// a RemoteSimulator is a ISimulator that connects to the Simularium Engine
-// back end server and plays back a trajectory specified in the NetConnectionParams
+// a RemoteSimulator is a ISimulator that connects to the Octopus back end server
+// and plays back a trajectory specified in the NetConnectionParams
 export class RemoteSimulator implements ISimulator {
     public webSocketClient: WebsocketClient;
     protected logger: ILogger;
@@ -29,16 +29,13 @@ export class RemoteSimulator implements ISimulator {
     public healthCheckHandler: () => void;
     protected lastRequestedFile: string;
     public handleError: (error: FrontEndError) => void | (() => void);
-    protected useOctopus: boolean;
 
     public constructor(
         webSocketClient: WebsocketClient,
-        useOctopus: boolean,
         errorHandler?: (error: FrontEndError) => void
     ) {
         this.webSocketClient = webSocketClient;
         this.lastRequestedFile = "";
-        this.useOctopus = useOctopus;
         this.handleError =
             errorHandler ||
             (() => {
@@ -310,19 +307,10 @@ export class RemoteSimulator implements ISimulator {
 
     public startRemoteTrajectoryPlayback(fileName: string): Promise<void> {
         this.lastRequestedFile = fileName;
-        let jsonData;
-        if (this.useOctopus) {
-            jsonData = {
-                msgType: NetMessageEnum.ID_INIT_TRAJECTORY_FILE,
-                fileName: fileName,
-            };
-        } else {
-            jsonData = {
-                msgType: NetMessageEnum.ID_VIS_DATA_REQUEST,
-                mode: PlayBackType.ID_TRAJECTORY_FILE_PLAYBACK,
-                "file-name": fileName,
-            };
-        }
+        const jsonData = {
+            msgType: NetMessageEnum.ID_INIT_TRAJECTORY_FILE,
+            fileName: fileName,
+        };
 
         // begins a stream which will include a TrajectoryFileInfo and a series of VisDataMessages
         // Note that it is possible for the first vis data to arrive before the TrajectoryFileInfo...

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -12,13 +12,6 @@ import { ISimulator } from "./ISimulator";
 import { TrajectoryFileInfoV2, VisDataMessage } from "./types";
 import { TrajectoryType } from "../constants";
 
-const enum PlayBackType {
-    ID_LIVE_SIMULATION = 0,
-    ID_PRE_RUN_SIMULATION = 1,
-    ID_TRAJECTORY_FILE_PLAYBACK = 2,
-    // insert new values here before LENGTH
-    LENGTH,
-}
 // a RemoteSimulator is a ISimulator that connects to the Octopus back end server
 // and plays back a trajectory specified in the NetConnectionParams
 export class RemoteSimulator implements ISimulator {
@@ -257,52 +250,16 @@ export class RemoteSimulator implements ISimulator {
 
     /**
      * WebSocket Simulation Control
-     *
-     * Simulation Run Modes:
-     *  Live : Results are sent as they are calculated
-     *  Pre-Run : All results are evaluated, then sent piecemeal
-     *  Trajectory File: No simulation run, stream a result file piecemeal
-     *
      */
     public startRemoteSimPreRun(
-        timeStep: number,
-        numTimeSteps: number
-    ): Promise<void> {
-        const jsonData = {
-            msgType: NetMessageEnum.ID_VIS_DATA_REQUEST,
-            mode: PlayBackType.ID_PRE_RUN_SIMULATION,
-            timeStep: timeStep,
-            numTimeSteps: numTimeSteps,
-        };
-
-        return this.connectToRemoteServer()
-            .then(() => {
-                this.webSocketClient.sendWebSocketRequest(
-                    jsonData,
-                    "Start Simulation Pre-Run"
-                );
-            })
-            .catch((e) => {
-                throw new FrontEndError(e.message, ErrorLevel.ERROR);
-            });
+        _timeStep: number,
+        _numTimeSteps: number
+    ): void {
+        // not implemented
     }
 
-    public startRemoteSimLive(): Promise<void> {
-        const jsonData = {
-            msgType: NetMessageEnum.ID_VIS_DATA_REQUEST,
-            mode: PlayBackType.ID_LIVE_SIMULATION,
-        };
-
-        return this.connectToRemoteServer()
-            .then(() => {
-                this.webSocketClient.sendWebSocketRequest(
-                    jsonData,
-                    "Start Simulation Live"
-                );
-            })
-            .catch((e) => {
-                throw new FrontEndError(e.message, ErrorLevel.ERROR);
-            });
+    public startRemoteSimLive(): void {
+        // not implemented
     }
 
     public startRemoteTrajectoryPlayback(fileName: string): Promise<void> {
@@ -363,7 +320,6 @@ export class RemoteSimulator implements ISimulator {
         this.webSocketClient.sendWebSocketRequest(
             {
                 msgType: NetMessageEnum.ID_VIS_DATA_REQUEST,
-                mode: PlayBackType.ID_TRAJECTORY_FILE_PLAYBACK,
                 frameNumber: startFrameNumber,
                 fileName: this.lastRequestedFile,
             },

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -15,11 +15,6 @@ import { FrontEndError, ErrorLevel } from "./FrontEndError";
 import type { ParsedBundle } from "./VisDataParse";
 import { parseVisDataMessage } from "./VisDataParse";
 
-// must be utf-8 encoded
-const EOF_PHRASE: Uint8Array = new TextEncoder().encode(
-    "\\EOFTHEFRAMEENDSHERE"
-);
-
 class VisData {
     private frameCache: AgentData[][];
     private frameDataCache: FrameData[];
@@ -28,7 +23,6 @@ class VisData {
     private frameToWaitFor: number;
     private lockedForFrame: boolean;
     private cacheFrame: number;
-    private netBuffer: ArrayBuffer;
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private _dragAndDropFileInfo: TrajectoryFileInfo | null;
@@ -93,147 +87,6 @@ class VisData {
         };
     }
 
-    public static parseBinary(data: ArrayBuffer): ParsedBundle {
-        const parsedAgentDataArray: AgentData[][] = [];
-        const frameDataArray: FrameData[] = [];
-
-        const byteView = new Uint8Array(data);
-        const length = byteView.length;
-        const lastEOF = length - EOF_PHRASE.length;
-        let end = 0;
-        let start = 0;
-
-        const frameDataView = new Float32Array(data);
-
-        while (end < lastEOF) {
-            // Find the next End of Frame signal
-            for (; end < length; end = end + 4) {
-                const curr = byteView.subarray(end, end + EOF_PHRASE.length);
-                if (curr.every((val, i) => val === EOF_PHRASE[i])) {
-                    break;
-                }
-            }
-
-            // contains Frame # | Time Stamp | # of Agents
-            const frameInfoView = frameDataView.subarray(
-                start / 4,
-                (start + 12) / 4
-            );
-
-            // contains parsable agents
-            const agentDataView = frameDataView.subarray(
-                (start + 12) / 4,
-                end / 4
-            );
-
-            const parsedFrameData = {
-                time: frameInfoView[1],
-                frameNumber: frameInfoView[0],
-            };
-            const expectedNumAgents = frameInfoView[2];
-            frameDataArray.push(parsedFrameData);
-
-            // Parse the frameData
-            const parsedAgentData: AgentData[] = [];
-            const nSubPointsIndex = AGENT_OBJECT_KEYS.findIndex(
-                (ele) => ele === "nSubPoints"
-            );
-
-            const parseOneAgent = (agentArray): AgentData => {
-                return agentArray.reduce(
-                    (agentData, cur, i) => {
-                        let key;
-                        if (AGENT_OBJECT_KEYS[i]) {
-                            key = AGENT_OBJECT_KEYS[i];
-                            agentData[key] = cur;
-                        } else if (
-                            i <
-                            agentArray.length + agentData.nSubPoints
-                        ) {
-                            agentData.subpoints.push(cur);
-                        }
-                        return agentData;
-                    },
-                    { subpoints: [] }
-                );
-            };
-
-            let dataIter = 0;
-            while (dataIter < agentDataView.length) {
-                const nSubPoints = agentDataView[dataIter + nSubPointsIndex];
-                if (
-                    !Number.isInteger(nSubPoints) ||
-                    !Number.isInteger(dataIter)
-                ) {
-                    throw new FrontEndError(
-                        "Your data is malformed, non-integer value found for num-subpoints.",
-                        ErrorLevel.ERROR,
-                        `Number of Subpoints: <pre>${nSubPoints}</pre>`
-                    );
-                    break;
-                }
-
-                // each array length is variable based on how many subpoints the agent has
-                const chunkLength = AGENT_OBJECT_KEYS.length + nSubPoints;
-                const remaining = agentDataView.length - dataIter;
-                if (remaining < chunkLength - 1) {
-                    const attemptedMapping = AGENT_OBJECT_KEYS.map(
-                        (name, index) =>
-                            `${name}: ${agentDataView[dataIter + index]}<br />`
-                    );
-                    // will be caught by controller.changeFile(...).catch()
-                    throw new FrontEndError(
-                        "Your data is malformed, non-integer value found for num-subpoints.",
-                        ErrorLevel.ERROR,
-                        `Example attempt to parse your data: <pre>${attemptedMapping.join(
-                            ""
-                        )}</pre>`
-                    );
-                }
-
-                const agentSubSetArray = agentDataView.subarray(
-                    dataIter,
-                    dataIter + chunkLength
-                );
-                if (agentSubSetArray.length < AGENT_OBJECT_KEYS.length) {
-                    const attemptedMapping = AGENT_OBJECT_KEYS.map(
-                        (name, index) =>
-                            `${name}: ${agentSubSetArray[index]}<br />`
-                    );
-                    // will be caught by controller.changeFile(...).catch()
-                    throw new FrontEndError(
-                        "Your data is malformed, there are less entries than expected for this agent.",
-                        ErrorLevel.ERROR,
-                        `Example attempt to parse your data: <pre>${attemptedMapping.join(
-                            ""
-                        )}</pre>`
-                    );
-                }
-
-                const agent = parseOneAgent(agentSubSetArray);
-                parsedAgentData.push(agent);
-                dataIter = dataIter + chunkLength;
-            }
-
-            const numParsedAgents = parsedAgentData.length;
-            if (numParsedAgents != expectedNumAgents) {
-                throw new FrontEndError(
-                    "Mismatch between expected num agents and parsed num agents, possible offset error"
-                );
-            }
-
-            parsedAgentDataArray.push(parsedAgentData);
-
-            start = end + EOF_PHRASE.length;
-            end = start;
-        }
-
-        return {
-            parsedAgentDataArray,
-            frameDataArray,
-        };
-    }
-
     private setupWebWorker() {
         this.webWorker = new Worker(
             new URL("../visGeometry/workers/visDataWorker", import.meta.url),
@@ -264,7 +117,6 @@ class VisData {
         this._dragAndDropFileInfo = null;
         this.frameToWaitFor = 0;
         this.lockedForFrame = false;
-        this.netBuffer = new ArrayBuffer(0);
         this.timeStepSize = 0;
     }
 
@@ -358,7 +210,6 @@ class VisData {
         this._dragAndDropFileInfo = null;
         this.frameToWaitFor = 0;
         this.lockedForFrame = false;
-        this.netBuffer = new ArrayBuffer(0);
     }
 
     public clearForNewTrajectory(): void {
@@ -449,80 +300,18 @@ class VisData {
             const fileNameSize = Math.ceil(floatView[1] / 4);
             const dataStart = (2 + fileNameSize) * 4;
 
-            this.parseBinaryNetData(msg as ArrayBuffer, dataStart);
+            const frames = VisData.parseOneBinaryFrame(msg.slice(dataStart));
+            if (
+                frames.frameDataArray.length > 0 &&
+                frames.frameDataArray[0].frameNumber === 0
+            ) {
+                this.clearCache(); // new data has arrived
+            }
+            this.addFramesToCache(frames);
             return;
         }
 
         this.parseAgentsFromVisDataMessage(msg);
-    }
-
-    private parseBinaryNetData(data: ArrayBuffer, dataStart: number) {
-        let eof = -1;
-
-        // find last '/eof' signal in new data
-        const byteView = new Uint8Array(data);
-
-        // walk backwards in order to find the last eofPhrase in the data
-        let index = byteView.length - EOF_PHRASE.length;
-        for (; index > 0; index = index - 4) {
-            const curr = byteView.subarray(index, index + EOF_PHRASE.length);
-            if (curr.every((val, i) => val === EOF_PHRASE[i])) {
-                eof = index;
-                break;
-            }
-        }
-
-        if (eof > dataStart) {
-            const frame = data.slice(dataStart, eof);
-
-            const tmp = new ArrayBuffer(
-                this.netBuffer.byteLength + frame.byteLength
-            );
-            new Uint8Array(tmp).set(new Uint8Array(this.netBuffer));
-            new Uint8Array(tmp).set(
-                new Uint8Array(frame),
-                this.netBuffer.byteLength
-            );
-
-            try {
-                const frames = VisData.parseBinary(tmp);
-                if (
-                    frames.frameDataArray.length > 0 &&
-                    frames.frameDataArray[0].frameNumber === 0
-                ) {
-                    this.clearCache(); // new data has arrived
-                }
-                this.addFramesToCache(frames);
-            } catch (err) {
-                // TODO: There are frequent errors due to a race condition that
-                // occurs when jumping to a new time if a partial frame is received
-                // after netBuffer is cleared. We don't want this to trigger a front
-                // end error, it's best to catch it here and just move on, as the
-                // issue should be contained to just one frame. When binary messages
-                // are updated to include frame num for partial frames in their header,
-                // we can ensure that netBuffer is being combined with the matching
-                // frame, and this try/catch can be removed
-                console.log(err);
-            }
-
-            // Save remaining data for later processing
-            const remainder = data.slice(eof + EOF_PHRASE.length);
-            this.netBuffer = new ArrayBuffer(remainder.byteLength);
-            new Uint8Array(this.netBuffer).set(new Uint8Array(remainder));
-        } else {
-            // Append the new data, and wait until eof
-            const frame = data.slice(dataStart, data.byteLength);
-            const tmp = new ArrayBuffer(
-                this.netBuffer.byteLength + frame.byteLength
-            );
-            new Uint8Array(tmp).set(new Uint8Array(this.netBuffer));
-            new Uint8Array(tmp).set(
-                new Uint8Array(frame),
-                this.netBuffer.byteLength
-            );
-
-            this.netBuffer = tmp;
-        }
     }
 
     // for use w/ a drag-and-drop trajectory file

--- a/src/simularium/WebsocketClient.ts
+++ b/src/simularium/WebsocketClient.ts
@@ -80,15 +80,12 @@ export const CONNECTION_FAIL_MSG =
 export interface NetConnectionParams {
     serverIp?: string;
     serverPort?: number;
-    secureConnection?: boolean;
-    useOctopus?: boolean;
 }
 
 export class WebsocketClient {
     private webSocket: WebSocket | null;
     private serverIp: string;
     private serverPort: number;
-    private secureConnection: boolean;
     public connectionTimeWaited: number;
     public connectionRetries: number;
     protected jsonMessageHandlers: Map<NetMessageEnum, (NetMessage) => void>;
@@ -114,10 +111,6 @@ export class WebsocketClient {
         >();
         this.serverIp = opts && opts.serverIp ? opts.serverIp : "localhost";
         this.serverPort = opts && opts.serverPort ? opts.serverPort : 9002;
-        this.secureConnection =
-            opts && opts.secureConnection !== undefined
-                ? opts.secureConnection
-                : true;
         this.connectionTimeWaited = 0;
         this.connectionRetries = 0;
         this.handleError =
@@ -260,9 +253,7 @@ export class WebsocketClient {
     }
 
     public getIp(): string {
-        return `${this.secureConnection ? "wss" : "ws"}://${this.serverIp}:${
-            this.serverPort
-        }/`;
+        return `wss://${this.serverIp}:${this.serverPort}/`;
     }
 
     public async waitForWebSocket(timeout: number): Promise<boolean> {

--- a/src/test/DummyRemoteSimulator.ts
+++ b/src/test/DummyRemoteSimulator.ts
@@ -21,7 +21,7 @@ export class DummyRemoteSimulator extends RemoteSimulator {
 
     public constructor(opts: NetConnectionParams) {
         const webSocketClient = new WebsocketClient(opts);
-        super(webSocketClient, true);
+        super(webSocketClient);
         this.webSocketClient = webSocketClient;
 
         this.isStreamingData = false;

--- a/src/test/RemoteSimulator.test.ts
+++ b/src/test/RemoteSimulator.test.ts
@@ -19,7 +19,7 @@ describe("RemoteSimulator", () => {
     describe("createWebSocket", () => {
         test("creates a WebSocket object", () => {
             const websocketClient = new WebsocketClient(CONNECTION_SETTINGS);
-            const simulator = new RemoteSimulator(websocketClient, true);
+            const simulator = new RemoteSimulator(websocketClient);
             expect(simulator.socketIsValid()).toBe(false);
 
             websocketClient.createWebSocket(simulator.getIp());
@@ -32,7 +32,7 @@ describe("RemoteSimulator", () => {
 
         test("returns true if connection succeeds within allotted time with no retries", async () => {
             const websocketClient = new WebsocketClient(CONNECTION_SETTINGS);
-            const simulator = new RemoteSimulator(websocketClient, true);
+            const simulator = new RemoteSimulator(websocketClient);
             jest.spyOn(websocketClient, "waitForWebSocket").mockResolvedValue(
                 true
             );
@@ -49,7 +49,7 @@ describe("RemoteSimulator", () => {
         });
         test("returns false if connection does not succeed within allotted time and number of retries", async () => {
             const websocketClient = new WebsocketClient(CONNECTION_SETTINGS);
-            const simulator = new RemoteSimulator(websocketClient, true);
+            const simulator = new RemoteSimulator(websocketClient);
             jest.spyOn(websocketClient, "waitForWebSocket").mockResolvedValue(
                 false
             );
@@ -67,7 +67,7 @@ describe("RemoteSimulator", () => {
         });
         test("returns true if connection succeeds on the retry", async () => {
             const websocketClient = new WebsocketClient(CONNECTION_SETTINGS);
-            const simulator = new RemoteSimulator(websocketClient, true);
+            const simulator = new RemoteSimulator(websocketClient);
             const waitForWebSocket = jest.spyOn(
                 websocketClient,
                 "waitForWebSocket"
@@ -116,7 +116,7 @@ describe("RemoteSimulator", () => {
     describe("startRemoteTrajectoryPlayback", () => {
         test("does not throw error if connectToRemoteServer succeeds", async () => {
             const websocketClient = new WebsocketClient(CONNECTION_SETTINGS);
-            const simulator = new RemoteSimulator(websocketClient, true);
+            const simulator = new RemoteSimulator(websocketClient);
             jest.spyOn(simulator, "connectToRemoteServer").mockResolvedValue(
                 CONNECTION_SUCCESS_MSG
             );
@@ -130,7 +130,7 @@ describe("RemoteSimulator", () => {
         });
         test("throws error emitted by connectToRemoteServer as a FrontEndError if connection fails", async () => {
             const websocketClient = new WebsocketClient(CONNECTION_SETTINGS);
-            const simulator = new RemoteSimulator(websocketClient, true);
+            const simulator = new RemoteSimulator(websocketClient);
             jest.spyOn(simulator, "connectToRemoteServer").mockRejectedValue(
                 new Error("Mock error message")
             );


### PR DESCRIPTION
Time Estimate or Size
=======
small

Problem
=======
As we fully transition to octopus, it's time to strip out the simularium-engine specific code that is no longer useful
[Link to story or ticket](https://github.com/simularium/simularium-viewer/issues/389)

Solution
========
* got rid of the `--octopus` commandline option, as that will now be the assumed platform
* got rid of the `useOctopus` option, as that will now be the assumed platform

A website PR will need to be made after this, updating their `NetConnectionParams` to remove `useOctopus`
