### PR TITLE
spread null agent object when parsing frames

### DIFF
--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -49,7 +49,7 @@ class VisData {
         let j = AGENTS_OFFSET;
         for (let i = 0; i < expectedNumAgents; i++) {
             //TODO use visType in AgentData and convert from "vis-type" here at parse time
-            const agentData: AgentData = NULL_AGENT;
+            const agentData: AgentData = { ...NULL_AGENT };
 
             for (let k = 0; k < AGENT_OBJECT_KEYS.length; ++k) {
                 agentData[AGENT_OBJECT_KEYS[k]] = floatView[j++];


### PR DESCRIPTION
Introduced a bug when I [merged this PR.](https://github.com/simularium/simularium-viewer/pull/392)

Not all agents rendering in viewport on load.

Source of bug: I created `NULL_AGENT` constant to stay DRY but ended up with pass-by-reference issues

Fix: using spread operator seems to be a quick fix.

Not sure how I missed this initially or if something changed in viewer or octopus, it seemed to be working well before, sorry.