### PR TITLE
export AgentData type properly from /types and / simularium

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type {
     EncodedTypeMapping,
     VisDataMessage,
     Plot,
+    AgentData,
 } from "./simularium";
 export type { ISimulariumFile } from "./simularium/ISimulariumFile";
 export type { TimeData } from "./viewport";
@@ -28,6 +29,5 @@ export {
 } from "./simularium";
 export { compareTimes, loadSimulariumFile } from "./util";
 export { DEFAULT_CAMERA_SPEC } from "./constants";
-export { AgentData } from "./simularium/types";
 
 export default Viewport;

--- a/src/simularium/index.ts
+++ b/src/simularium/index.ts
@@ -8,6 +8,7 @@ export type {
     EncodedTypeMapping,
     SimulariumFileFormat,
     Plot,
+    AgentData,
 } from "./types";
 
 export type {


### PR DESCRIPTION
Time Estimate or Size
=======
_tiny_

Problem/Solution
=======
`AgentData` isn't currently being exported as a type, which creates an error, this gets it exported as a type and in the same way as the other types.
