### PR TITLE
code cleanup: dragAndDrop and JSON caching code

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -497,13 +497,6 @@ export default class SimulariumController {
         this.visData.clearCache();
     }
 
-    public get dragAndDropFileInfo(): TrajectoryFileInfo | null {
-        return this.visData.dragAndDropFileInfo;
-    }
-    public set dragAndDropFileInfo(fileInfo: TrajectoryFileInfo | null) {
-        this.visData.dragAndDropFileInfo = fileInfo;
-    }
-
     public set trajFileInfoCallback(
         callback: (msg: TrajectoryFileInfo) => void
     ) {

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,11 +1,7 @@
 import jsLogger from "js-logger";
 import { isEmpty, noop } from "lodash";
 import { VisData, RemoteSimulator } from "../simularium";
-import type {
-    NetConnectionParams,
-    TrajectoryFileInfo,
-    VisDataMessage,
-} from "../simularium";
+import type { NetConnectionParams, TrajectoryFileInfo } from "../simularium";
 import { VisGeometry } from "../visGeometry";
 import {
     FileReturn,

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -489,10 +489,6 @@ export default class SimulariumController {
         }
     }
 
-    public cacheJSON(json: VisDataMessage): void {
-        this.visData.cacheJSON(json);
-    }
-
     public clearLocalCache(): void {
         this.visData.clearCache();
     }

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -307,20 +307,6 @@ class VisData {
 
         this.parseAgentsFromFrameData(msg);
     }
-
-    // for use w/ a drag-and-drop trajectory file
-    //  save a file for playback
-    // will be caught by controller.changeFile(...).catch()
-    public cacheJSON(visDataMsg: VisDataMessage): void {
-        if (this.frameCache.length > 0) {
-            throw new Error(
-                "cache not cleared before cacheing a new drag-and-drop file"
-            );
-        }
-
-        const frames = parseVisDataMessage(visDataMsg);
-        this.addFramesToCache(frames);
-    }
 }
 
 export { VisData };

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -26,9 +26,6 @@ class VisData {
     private lockedForFrame: boolean;
     private cacheFrame: number;
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    private _dragAndDropFileInfo: TrajectoryFileInfo | null;
-
     public timeStepSize: number;
 
     private static parseOneBinaryFrame(data: ArrayBuffer): ParsedBundle {
@@ -109,7 +106,6 @@ class VisData {
         this.frameDataCache = [];
         this.cacheFrame = -1;
         this.enableCache = true;
-        this._dragAndDropFileInfo = null;
         this.frameToWaitFor = 0;
         this.lockedForFrame = false;
         this.timeStepSize = 0;
@@ -206,7 +202,6 @@ class VisData {
         this.frameCache = [];
         this.frameDataCache = [];
         this.cacheFrame = -1;
-        this._dragAndDropFileInfo = null;
         this.frameToWaitFor = 0;
         this.lockedForFrame = false;
     }
@@ -325,54 +320,6 @@ class VisData {
 
         const frames = parseVisDataMessage(visDataMsg);
         this.addFramesToCache(frames);
-    }
-
-    public set dragAndDropFileInfo(fileInfo: TrajectoryFileInfo | null) {
-        if (!fileInfo) return;
-        // NOTE: this may be a temporary check as we're troubleshooting new file formats
-        const missingIds = this.checkTypeMapping(fileInfo.typeMapping);
-
-        if (missingIds.length) {
-            const include = confirm(
-                `Your file typeMapping is missing names for the following type ids: ${missingIds}. Do you want to include them in the interactive interface?`
-            );
-            if (include) {
-                missingIds.forEach((id) => {
-                    fileInfo.typeMapping[id] = { name: id.toString() };
-                });
-            }
-        }
-        this._dragAndDropFileInfo = fileInfo;
-    }
-
-    public get dragAndDropFileInfo(): TrajectoryFileInfo | null {
-        if (!this._dragAndDropFileInfo) {
-            return null;
-        }
-        return this._dragAndDropFileInfo;
-    }
-
-    // will be caught by controller.changeFile(...).catch()
-    // TODO: check if this code is still used
-    public checkTypeMapping(typeMappingFromFile: EncodedTypeMapping): number[] {
-        if (!typeMappingFromFile) {
-            throw new Error(
-                "data needs 'typeMapping' object to display agent controls"
-            );
-        }
-        const idsInFrameData = new Set();
-        const idsInTypeMapping = Object.keys(typeMappingFromFile).map(Number);
-
-        if (this.frameCache.length === 0) {
-            console.log("no data to check type mapping against");
-            return [];
-        }
-
-        this.frameCache.forEach((element) => {
-            element.map((agent) => idsInFrameData.add(agent.type));
-        });
-        const idsArr: number[] = [...idsInFrameData].sort() as number[];
-        return difference(idsArr, idsInTypeMapping).sort();
     }
 }
 

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -1,5 +1,3 @@
-import { difference } from "lodash";
-
 import { compareTimes } from "../util";
 
 import * as util from "./ThreadUtil";
@@ -7,8 +5,6 @@ import {
     AGENT_OBJECT_KEYS,
     AgentData,
     FrameData,
-    TrajectoryFileInfo,
-    EncodedTypeMapping,
     VisDataMessage,
 } from "./types";
 import { FrontEndError, ErrorLevel } from "./FrontEndError";


### PR DESCRIPTION
Time Estimate or Size
=======
_xsmall_

Problem
=======
Closes #224 

Remove unused code in viewer related to loading local JSON and local files.

It's possible there is more code we can remove, bigger changes are coming to `VisData` in caching refactor. This smooths the path for that slightly, as the `checkTypeMapping` function would require parsing data before we want to in the new paradigm.

Tested that dragging and dropping local JSON works in both viewer and website.

Steps to Verify:
----------------
1. Drag and drop some local JSON trajectories into the viewer
