### PR TITLE
remove unused references to colorchange interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ export type {
     SelectionStateInfo,
     UIDisplayData,
     VisDataFrame,
-    ColorChange,
     SelectionEntry,
     TrajectoryFileInfo,
     NetConnectionParams,

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -18,11 +18,6 @@ export interface SelectionEntry {
     tags: string[];
 }
 
-export interface ColorChange {
-    agent: SelectionEntry;
-    color: string;
-}
-
 export interface SelectionStateInfo {
     highlightedAgents: SelectionEntry[];
     hiddenAgents: SelectionEntry[];

--- a/src/simularium/index.ts
+++ b/src/simularium/index.ts
@@ -15,7 +15,6 @@ export type {
     SelectionStateInfo,
     UIDisplayData,
     SelectionEntry,
-    ColorChange,
 } from "./SelectionInterface";
 export { ErrorLevel, FrontEndError } from "./FrontEndError";
 export { NetMessageEnum } from "./WebsocketClient";


### PR DESCRIPTION
Time Estimate or Size
=======
_tiny_

Problem
=======
Discussion [here](https://github.com/simularium/simularium-website/pull/545)
This interface isn't used in the viewer anymore, will define and use on front end as needed, removing this code.
