### PR TITLE
remove pauseOn property

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ class Viewer extends React.Component {
         this.viewerRef = React.createRef();
 
         this.state = {
-               highlightId: -1,
-                pauseOn: -1,
+                highlightId: -1,
                 particleTypeIds: [],
                 currentFrame: 0,
                 currentTime: 0,

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -84,7 +84,6 @@ const agentColors = [
 
 interface ViewerState {
     renderStyle: RenderStyle;
-    pauseOn: number;
     particleTypeNames: string[];
     particleTypeTags: string[];
     currentFrame: number;
@@ -149,7 +148,6 @@ let currentTime = 0;
 
 const initialState: ViewerState = {
     renderStyle: RenderStyle.WEBGL2_PREFERRED,
-    pauseOn: -1,
     particleTypeNames: [],
     particleTypeTags: [],
     currentFrame: 0,
@@ -429,9 +427,8 @@ class Viewer extends React.Component<InputParams, ViewerState> {
             this.setState({ initialPlay: false, firstFrameTime: currentTime });
         }
         this.setState({ currentFrame, currentTime });
-        if (this.state.pauseOn === currentFrame) {
+        if (currentFrame < 0) {
             simulariumController.pause();
-            this.setState({ pauseOn: -1 });
         }
     }
 


### PR DESCRIPTION
Time Estimate or Size
=======
_tiny_

Problem
=======
The `pauseOn` property seems to be dead code. I'm fiddling with `pause` behavior on another branch and noticed this.

`pauseOn` is initialized to -1, never reassigned, and only access to do one comparison. 

We can just ask if `currentFrame < 0`, unless I'm missing something?
