### PR TITLE
fix test bed download button

### DIFF
--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -942,7 +942,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 >
                     Get available metrics
                 </button>
-                <button onClick={() => this.downloadFile()}>download</button>
+                <button onClick={this.downloadFile.bind(this)}>download</button>
                 <button
                     onClick={() =>
                         simulariumController.getPlotData(

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -942,7 +942,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 >
                     Get available metrics
                 </button>
-                <button onClick={this.downloadFile}>download</button>
+                <button onClick={() => this.downloadFile()}>download</button>
                 <button
                     onClick={() =>
                         simulariumController.getPlotData(


### PR DESCRIPTION
Time Estimate or Size
=======
_tiny_

Problem
=======
Somewhere along the line we broke the test-bed download button, it was losing the context and state was coming back undefined, arrow function in button `onClick` restores context
