### PR TITLE
Feature/prefetching

### DIFF
--- a/examples/src/Components/CacheAndStreamingLogs.tsx
+++ b/examples/src/Components/CacheAndStreamingLogs.tsx
@@ -42,13 +42,6 @@ const CacheAndStreamingLogs: React.FC<StreamingReadoutProps> = ({
         }));
     }, [firstFrameNumber, getFirstFrameNumber, lastFrameNumber]);
 
-    const calculateRatio = () => {
-        const first = Math.max(firstFrameNumber, getFirstFrameNumber());
-        const last = Math.max(lastFrameNumber, getLastFrameNumber());
-        if (last <= first || currentPlaybackFrame < first) return 0;
-        return (last - currentPlaybackFrame) / (last - first);
-    };
-
     return (
         <div>
             <button onClick={() => setIsOpen(!isOpen)}>

--- a/examples/src/Components/CacheAndStreamingLogs.tsx
+++ b/examples/src/Components/CacheAndStreamingLogs.tsx
@@ -2,27 +2,24 @@ import React, { useState } from "react";
 import { CacheLog } from "../../../src";
 
 interface StreamingReadoutProps {
-    playbackState: string;
-    streamingState: string;
+    playbackPlayingState: boolean;
+    isStreamingState: boolean;
     cacheLog: CacheLog;
+    playbackFrame: number;
     totalDuration: number;
 }
 
 const CacheAndStreamingLogs: React.FC<StreamingReadoutProps> = ({
-    playbackState,
-    streamingState,
+    playbackPlayingState,
+    isStreamingState,
     cacheLog,
+    playbackFrame,
     totalDuration,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
 
-    const {
-        size,
-        enabled,
-        maxSize,
-        firstFrameNumber,
-        lastFrameNumber,
-    } = cacheLog;
+    const { size, enabled, maxSize, firstFrameNumber, lastFrameNumber } =
+        cacheLog;
     return (
         <div>
             <button onClick={() => setIsOpen(!isOpen)}>
@@ -33,15 +30,22 @@ const CacheAndStreamingLogs: React.FC<StreamingReadoutProps> = ({
 
             {isOpen && (
                 <>
-                    <div>Playback State: {playbackState}</div>
-                    <div>Streaming State: {streamingState}</div>
+                    <div>
+                        Playback State:{" "}
+                        {playbackPlayingState === true ? "playing" : "paused"}
+                    </div>
+                    <div>
+                        Streaming State:{" "}
+                        {isStreamingState == true
+                            ? "streaming"
+                            : "not streaming"}
+                    </div>
                     <div>Cache Size: {size}</div>
                     <div>Cache Enabled: {enabled ? "Yes" : "No"}</div>
                     <div>Max Size: {maxSize}</div>
-                    <div>
-                        First Frame Number: {firstFrameNumber}
-                    </div>
+                    <div>First Frame Number: {firstFrameNumber}</div>
                     <div>Last Frame Number: {lastFrameNumber}</div>
+                    <div>Current playback frame: {playbackFrame}</div>
                     <div>Total Duration: {totalDuration}</div>
                 </>
             )}

--- a/examples/src/Components/CacheAndStreamingLogs.tsx
+++ b/examples/src/Components/CacheAndStreamingLogs.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from "react";
+
+interface StreamingReadoutProps {
+    playbackState: string;
+    streamingState: string;
+    cacheSize: number;
+    cacheEnabled: boolean;
+    maxSize: number;
+    firstFrameNumber: number;
+    lastFrameNumber: number;
+    currentPlaybackFrame: number;
+    totalDuration: number;
+    getFirstFrameNumber: () => number;
+    getLastFrameNumber: () => number;
+}
+
+const CacheAndStreamingLogs: React.FC<StreamingReadoutProps> = ({
+    playbackState,
+    streamingState,
+    cacheSize,
+    cacheEnabled,
+    maxSize,
+    firstFrameNumber,
+    lastFrameNumber,
+    currentPlaybackFrame,
+    totalDuration,
+    getFirstFrameNumber,
+    getLastFrameNumber,
+}) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [debugInfo, setDebugInfo] = useState({
+        directFirst: -1,
+        functionFirst: -1,
+        renderCount: 0,
+    });
+
+    useEffect(() => {
+        setDebugInfo((prev) => ({
+            directFirst: firstFrameNumber,
+            functionFirst: getFirstFrameNumber(),
+            renderCount: prev.renderCount + 1,
+        }));
+    }, [firstFrameNumber, getFirstFrameNumber, lastFrameNumber]);
+
+    const calculateRatio = () => {
+        const first = Math.max(firstFrameNumber, getFirstFrameNumber());
+        const last = Math.max(lastFrameNumber, getLastFrameNumber());
+        if (last <= first || currentPlaybackFrame < first) return 0;
+        return (last - currentPlaybackFrame) / (last - first);
+    };
+
+    return (
+        <div>
+            <button onClick={() => setIsOpen(!isOpen)}>
+                {isOpen ? "Hide Cache and Streaming Info" : "Show Cache and Streaming Info"}
+            </button>
+
+            {isOpen && (
+                <>
+                    <div>Playback State: {playbackState}</div>
+                    <div>Streaming State: {streamingState}</div>
+                    <div>Cache Size: {cacheSize}</div>
+                    <div>Cache Enabled: {cacheEnabled ? "Yes" : "No"}</div>
+                    <div>Max Size: {maxSize}</div>
+                    <div>First Frame Number: {getFirstFrameNumber()} this is buggy and shows a stale value even when i can log a different value with hasFrames()</div>
+                    <div>Last Frame Number: {getLastFrameNumber()}</div>
+                    <div>Total Duration: {totalDuration}</div>
+                    <div className="debug-info">
+                        <div className="debug-header">Debug Info:</div>
+                        <div className="debug-item">
+                            Render Count: {debugInfo.renderCount}
+                        </div>
+                        <div className="debug-item">
+                            Direct First Frame: {debugInfo.directFirst}
+                        </div>
+                        <div className="debug-item">
+                            Function First Frame: {debugInfo.functionFirst}
+                        </div>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default CacheAndStreamingLogs;

--- a/examples/src/Components/CacheAndStreamingLogs.tsx
+++ b/examples/src/Components/CacheAndStreamingLogs.tsx
@@ -1,75 +1,48 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
+import { CacheLog } from "../../../src";
 
 interface StreamingReadoutProps {
     playbackState: string;
     streamingState: string;
-    cacheSize: number;
-    cacheEnabled: boolean;
-    maxSize: number;
-    firstFrameNumber: number;
-    lastFrameNumber: number;
-    currentPlaybackFrame: number;
+    cacheLog: CacheLog;
     totalDuration: number;
-    getFirstFrameNumber: () => number;
-    getLastFrameNumber: () => number;
 }
 
 const CacheAndStreamingLogs: React.FC<StreamingReadoutProps> = ({
     playbackState,
     streamingState,
-    cacheSize,
-    cacheEnabled,
-    maxSize,
-    firstFrameNumber,
-    lastFrameNumber,
-    currentPlaybackFrame,
+    cacheLog,
     totalDuration,
-    getFirstFrameNumber,
-    getLastFrameNumber,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
-    const [debugInfo, setDebugInfo] = useState({
-        directFirst: -1,
-        functionFirst: -1,
-        renderCount: 0,
-    });
 
-    useEffect(() => {
-        setDebugInfo((prev) => ({
-            directFirst: firstFrameNumber,
-            functionFirst: getFirstFrameNumber(),
-            renderCount: prev.renderCount + 1,
-        }));
-    }, [firstFrameNumber, getFirstFrameNumber, lastFrameNumber]);
-
+    const {
+        size,
+        enabled,
+        maxSize,
+        firstFrameNumber,
+        lastFrameNumber,
+    } = cacheLog;
     return (
         <div>
             <button onClick={() => setIsOpen(!isOpen)}>
-                {isOpen ? "Hide Cache and Streaming Info" : "Show Cache and Streaming Info"}
+                {isOpen
+                    ? "Hide Cache and Streaming Info"
+                    : "Show Cache and Streaming Info"}
             </button>
 
             {isOpen && (
                 <>
                     <div>Playback State: {playbackState}</div>
                     <div>Streaming State: {streamingState}</div>
-                    <div>Cache Size: {cacheSize}</div>
-                    <div>Cache Enabled: {cacheEnabled ? "Yes" : "No"}</div>
+                    <div>Cache Size: {size}</div>
+                    <div>Cache Enabled: {enabled ? "Yes" : "No"}</div>
                     <div>Max Size: {maxSize}</div>
-                    <div>First Frame Number: {getFirstFrameNumber()} this is buggy and shows a stale value even when i can log a different value with hasFrames()</div>
-                    <div>Last Frame Number: {getLastFrameNumber()}</div>
-                    <div>Total Duration: {totalDuration}</div>
-                    <div className="debug-info">
-                        <div className="debug-header">Debug Info:</div>
-                        <div className="debug-item">
-                            Render Count: {debugInfo.renderCount}
-                        </div>
-                        <div className="debug-item">
-                            Direct First Frame: {debugInfo.directFirst}
-                        </div>
-                        <div className="debug-item">
-                            Function First Frame: {debugInfo.functionFirst}
-                        </div>
+                    <div>
+                        First Frame Number: {firstFrameNumber}
                     </div>
+                    <div>Last Frame Number: {lastFrameNumber}</div>
+                    <div>Total Duration: {totalDuration}</div>
                 </>
             )}
         </div>

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -24,6 +24,7 @@ import SimulariumViewer, {
     ErrorLevel,
     NetConnectionParams,
     TrajectoryFileInfo,
+    CacheLog,
 } from "../../src/index";
 import { nullAgent, TrajectoryType } from "../../src/constants";
 
@@ -96,6 +97,7 @@ interface ViewerState {
     initialPlay: boolean;
     firstFrameTime: number;
     followObjectData: AgentData;
+    cacheLog: CacheLog;
 }
 
 const simulariumController = new SimulariumController({});
@@ -129,6 +131,16 @@ const initialState: ViewerState = {
     initialPlay: true,
     firstFrameTime: 0,
     followObjectData: nullAgent(),
+    cacheLog: {
+        size: 0,
+        numFrames: 0,
+        maxSize: 0,
+        enabled: false,
+        firstFrameNumber: 0,
+        firstFrameTime: 0,
+        lastFrameNumber: 0,
+        lastFrameTime: 0,
+    },
 };
 
 class Viewer extends React.Component<InputParams, ViewerState> {
@@ -680,6 +692,13 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         this.setState({ followObjectData: agentData });
     };
 
+    public handleCacheUpdate = (log: CacheLog) => {
+           this.setState({
+            cacheLog: log
+        });
+    }
+
+
     public render(): JSX.Element {
         if (this.state.filePending) {
             const fileType = this.state.filePending.type;
@@ -766,11 +785,11 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                 <button onClick={() => simulariumController.resumePlayback()}>
                     Play
                 </button>
-                <button onClick={this.handlePause.bind(this)}>Pause</button>
+                <button onClick={this.handlePause.bind(this)}>Pause playback</button>
                 <button
                     onClick={() => simulariumController.abortRemoteSimulation()}
                 >
-                    stop
+                    stop / abort sim
                 </button>
                 <button onClick={this.gotoPreviousFrame.bind(this)}>
                     Previous Frame
@@ -979,16 +998,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                             ? "streaming"
                             : "not streaming"
                     }
-                    cacheSize={simulariumController.visData.frameCache.size}
-                    cacheEnabled={
-                        simulariumController.visData.frameCache.cacheEnabled
-                    }
-                    maxSize={simulariumController.visData.frameCache.maxSize}
-                    firstFrameNumber={simulariumController.visData.frameCache.getFirstFrameNumber()}
-                    lastFrameNumber={simulariumController.visData.frameCache.getLastFrameNumber()}
-                    getFirstFrameNumber={() => {return simulariumController.visData.frameCache.head?.data.frameNumber! || 66}}
-                    getLastFrameNumber={() => simulariumController.visData.frameCache.getLastFrameNumber()}
-                    currentPlaybackFrame={this.state.currentFrame}
+                    cacheLog={this.state.cacheLog}
                     totalDuration={Math.ceil(
                         this.state.totalDuration / this.state.timeStep
                     )}
@@ -1027,6 +1037,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                         lockedCamera={false}
                         disableCache={false}
                         maxCacheSize={Infinity} //  means no limit, provide limits in bytes, 1MB = 1000000, 1GB = 1000000000
+                        onCacheUpdate={this.handleCacheUpdate.bind(this)}
                     />
                 </div>
             </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,3 +54,4 @@ export const nullAgent = (): AgentData => {
 export const AGENT_HEADER_SIZE = 3; // frameNumber, time, agentCount
 
 export const BYTE_SIZE_64_BIT_NUM = 8;
+export const DEFAULT_PRE_FETCH_RATIO = 0;

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -220,6 +220,7 @@ export default class SimulariumController {
     public abortRemoteSimulation(): void {
         if (this.simulator) {
             this.simulator.abortRemoteSim();
+            this.isStreaming = false;
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type {
     VisDataMessage,
     Plot,
     AgentData,
+    CacheLog,
 } from "./simularium";
 export type { ISimulariumFile } from "./simularium/ISimulariumFile";
 export type { TimeData } from "./viewport";

--- a/src/simularium/VisDataCache.ts
+++ b/src/simularium/VisDataCache.ts
@@ -15,7 +15,6 @@ class VisDataCache {
     public size: number;
     private _maxSize: number;
     private _cacheEnabled: boolean;
-    private _preFetchRatio: number;
     private cacheUpdateCallback: ((log: CacheLog) => void) | null;
 
     constructor(settings?: Partial<VisDataCacheSettings>) {
@@ -31,7 +30,6 @@ class VisDataCache {
         this.size = 0;
         this._maxSize = Infinity;
         this._cacheEnabled = true;
-        this._preFetchRatio = DEFAULT_PRE_FETCH_RATIO;
         this.cacheUpdateCallback = null;
 
         if (settings) {
@@ -81,10 +79,6 @@ class VisDataCache {
 
     public get cacheSizeLimited(): boolean {
         return this._maxSize !== Infinity;
-    }
-
-    public get preFetchRatio(): number {
-        return this._preFetchRatio;
     }
 
     public hasFrames(): boolean {

--- a/src/simularium/index.ts
+++ b/src/simularium/index.ts
@@ -9,6 +9,7 @@ export type {
     SimulariumFileFormat,
     Plot,
     AgentData,
+    CacheLog,
 } from "./types";
 
 export type {

--- a/src/simularium/types.ts
+++ b/src/simularium/types.ts
@@ -209,3 +209,13 @@ export interface CacheNode {
     next: CacheNode | null;
     prev: CacheNode | null;
 }
+export interface CacheLog {
+    size: number;
+    numFrames: number;
+    maxSize: number;
+    enabled: boolean;
+    firstFrameNumber: number;
+    firstFrameTime: number;
+    lastFrameNumber: number;
+    lastFrameTime: number;
+}

--- a/src/test/AgentSimController.test.ts
+++ b/src/test/AgentSimController.test.ts
@@ -14,8 +14,8 @@ describe("SimulariumController module", () => {
                 remoteSimulator: netConn,
             });
 
-            controller.start();
-            controller.gotoTime(2);
+            controller.initializePrecomputedSimulation();
+            controller.movePlaybackTime(2);
 
             // allow time for data streaming to occur
             setTimeout(() => {

--- a/src/test/SimulariumController.test.ts
+++ b/src/test/SimulariumController.test.ts
@@ -14,8 +14,8 @@ describe("SimulariumController module", () => {
                 remoteSimulator: netConn,
             });
 
-            controller.start();
-            controller.gotoTime(2);
+            controller.initializePrecomputedSimulation();
+            controller.movePlaybackTime(2);
             setTimeout(() => {
                 expect(controller.time()).toEqual(2);
                 done();

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -48,6 +48,7 @@ type ViewportProps = {
     disableCache?: boolean;
     onFollowObjectChanged?: (agentData: AgentData) => void; // passes agent data about the followed agent to the front end
     maxCacheSize?: number;
+    preFetchRatio?: number;
 } & Partial<DefaultProps>;
 
 const defaultProps = {
@@ -130,6 +131,7 @@ class Viewport extends React.Component<
         this.props.simulariumController.visData.frameCache.changeSettings({
             cacheEnabled: !props.disableCache,
             maxSize: props.maxCacheSize,
+            preFetchRatio: props.preFetchRatio,
         });
         if (props.onError) {
             this.props.simulariumController.visData.setOnError(props.onError);
@@ -187,6 +189,7 @@ class Viewport extends React.Component<
 
         simulariumController.visData.timeStepSize =
             trajectoryFileInfo.timeStepSize;
+        simulariumController.visData.totalSteps = trajectoryFileInfo.totalSteps;
 
         const bx = trajectoryFileInfo.size.x;
         const by = trajectoryFileInfo.size.y;
@@ -319,6 +322,7 @@ class Viewport extends React.Component<
             selectionStateInfo,
             lockedCamera,
             disableCache,
+            preFetchRatio,
         } = this.props;
 
         if (selectionStateInfo) {
@@ -384,6 +388,11 @@ class Viewport extends React.Component<
         if (prevProps.disableCache !== disableCache) {
             this.props.simulariumController.visData.frameCache.changeSettings({
                 cacheEnabled: !disableCache,
+            });
+        }
+        if (prevProps.preFetchRatio !== preFetchRatio) {
+            this.props.simulariumController.visData.frameCache.changeSettings({
+                preFetchRatio: preFetchRatio,
             });
         }
         if (prevState.showRenderParamsGUI !== this.state.showRenderParamsGUI) {
@@ -657,7 +666,7 @@ class Viewport extends React.Component<
                 }
             }
 
-            if (!visData.atLatestFrame() && !simulariumController.paused()) {
+            if (!visData.atLatestFrame() && !simulariumController.playbackPaused()) {
                 visData.gotoNextFrame();
             }
             this.stats.begin();

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -11,6 +11,7 @@ import {
     SelectionInterface,
     SelectionStateInfo,
     UIDisplayData,
+    CacheLog,
 } from "../simularium";
 import { AgentData, TrajectoryFileInfoAny } from "../simularium/types";
 import { updateTrajectoryFileInfoFormat } from "../simularium/versionHandlers";
@@ -49,6 +50,7 @@ type ViewportProps = {
     onFollowObjectChanged?: (agentData: AgentData) => void; // passes agent data about the followed agent to the front end
     maxCacheSize?: number;
     preFetchRatio?: number;
+    onCacheUpdate?: (log: CacheLog) => void;
 } & Partial<DefaultProps>;
 
 const defaultProps = {
@@ -131,7 +133,7 @@ class Viewport extends React.Component<
         this.props.simulariumController.visData.frameCache.changeSettings({
             cacheEnabled: !props.disableCache,
             maxSize: props.maxCacheSize,
-            preFetchRatio: props.preFetchRatio,
+            onUpdate: props.onCacheUpdate,
         });
         if (props.onError) {
             this.props.simulariumController.visData.setOnError(props.onError);

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -49,7 +49,6 @@ type ViewportProps = {
     disableCache?: boolean;
     onFollowObjectChanged?: (agentData: AgentData) => void; // passes agent data about the followed agent to the front end
     maxCacheSize?: number;
-    preFetchRatio?: number;
     onCacheUpdate?: (log: CacheLog) => void;
 } & Partial<DefaultProps>;
 
@@ -324,7 +323,6 @@ class Viewport extends React.Component<
             selectionStateInfo,
             lockedCamera,
             disableCache,
-            preFetchRatio,
         } = this.props;
 
         if (selectionStateInfo) {
@@ -390,11 +388,6 @@ class Viewport extends React.Component<
         if (prevProps.disableCache !== disableCache) {
             this.props.simulariumController.visData.frameCache.changeSettings({
                 cacheEnabled: !disableCache,
-            });
-        }
-        if (prevProps.preFetchRatio !== preFetchRatio) {
-            this.props.simulariumController.visData.frameCache.changeSettings({
-                preFetchRatio: preFetchRatio,
             });
         }
         if (prevState.showRenderParamsGUI !== this.state.showRenderParamsGUI) {

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -50,6 +50,7 @@ type ViewportProps = {
     onFollowObjectChanged?: (agentData: AgentData) => void; // passes agent data about the followed agent to the front end
     maxCacheSize?: number;
     onCacheUpdate?: (log: CacheLog) => void;
+    onStreamingChange?: (streaming: boolean) => void;
 } & Partial<DefaultProps>;
 
 const defaultProps = {
@@ -136,6 +137,11 @@ class Viewport extends React.Component<
         });
         if (props.onError) {
             this.props.simulariumController.visData.setOnError(props.onError);
+        }
+        if (props.onStreamingChange) {
+            this.props.simulariumController.visData.setOnStreamingChange(
+                props.onStreamingChange
+            );
         }
         this.props.simulariumController.visData.clearCache();
         this.visGeometry.createMaterials(props.agentColors);
@@ -661,7 +667,7 @@ class Viewport extends React.Component<
                 }
             }
 
-            if (!visData.atLatestFrame() && !simulariumController.playbackPaused()) {
+            if (!visData.atLatestFrame() && simulariumController.isPlaying()) {
                 visData.gotoNextFrame();
             }
             this.stats.begin();


### PR DESCRIPTION
DRAFT
Still sorting out the last details of keeping remote playback time in sync with local, and what to do when hitting the cache limit in various states

Time Estimate or Size
=======
_medium_

long discussion below!

tl;dr is we can probably merge this feature with basic review, but this work might usefully branch into some deeper refactoring

Problem
=======
Closes #423 advances #424

Solution
========

This is a working prototype or version of prefetching frames from networked/precomputed simulations. The primary idea here it to make explicit the difference between playback and streaming.

There are places now where the two are somewhat conflated, as in "pausing" means "pausing the stream of frames from the back end" and also means "stop advancing the rendered frame in the viewer"

- Previously in viewport: `isPaused` -> now: `isStreaming` and `isPlaybackPaused`
- Expose a callback in the cache to log changes and observe the growing size, first and last frame number, etc.
- Small component in test bed to print these logs
- Renaming controller methods to make explicit whether they relate to playback or streaming control





I had a chat with @toloudis and looked at this todo in the `ISimulator`:
```
    /**
     * Simulation Control
     *
     * Simulation Run Modes:
     *  Live : Results are sent as they are calculated
     *  Pre-Run : All results are evaluated, then sent piecemeal
     *  Trajectory File: No simulation run, stream a result file piecemeal
     *
     */
    // these should probably be abstracted to just "start"
    // and have a separate interface for initialization?
    // For example, "start" = initialize, and "resume" = play
    startRemoteSimPreRun(timeStep: number, numTimeSteps: number): void;
    startRemoteSimLive(): void;
    startRemoteTrajectoryPlayback(fileName: string): Promise<void>;
    sendModelDefinition(model: string): void;
``` 
I'd like to get some opinions and form a plan on touching up `ISimulator` and the websocket messaging protocol naming, in conjunction with the front end clarifying the naming of what is playback and what is streaming/communicating with the backend. This will be another step toward making live mode a reality, and building on the work @blairlyons and @ascibisz have been doing on the BioSimulators API.

There was also discussion of whether the `SimulariumController`, which was originally intended to expose controls that the website might access, is doing to many things, and some new abstractions for managing streaming and loading of trajectories would be in order.

I definitely don't want to charge into these APIs and start making a lot of changes, but looking at the todo above and chatting with @toloudis about it I do think its a good moment to step back and look at this! Maybe a good topic to touch on at PM meeting on 12/10 or go more in depth at dev meeting 12/17? Or bump to 2025.

Either way, this feature branch works, makes prefetching a thing, and can move forward independent of the discussion above, but it's all connected.

Steps to Verify:
----------------
1. Inspect the log outputs with the button at the bottom of the viewer controls, and how they relate to playback.

