### PR TITLE
Fix/autoconversion

### DIFF
--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -119,7 +119,7 @@ const initialState: ViewerState = {
     trajectoryTitle: "",
     initialPlay: true,
     firstFrameTime: 0,
-    followObjectData: nullAgent(),
+    followObjectData: null,
     conversionFileName: "",
 };
 

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { map, isEqual, findIndex, reduce } from "lodash";
+import { isEqual, findIndex, reduce, map as lodashMap } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 import { InputParams } from "tweakpane";
 
@@ -87,7 +87,7 @@ interface ViewerState {
     initialPlay: boolean;
     firstFrameTime: number;
     followObjectData: AgentData;
-    convertingFile: boolean;
+    conversionActive: boolean;
     conversionFileName: string;
 }
 
@@ -122,7 +122,7 @@ const initialState: ViewerState = {
     initialPlay: true,
     firstFrameTime: 0,
     followObjectData: nullAgent(),
-    convertingFile: false,
+    conversionActive: false,
     conversionFileName: "",
 };
 
@@ -288,7 +288,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
             .then((data) => data.json())
             .then((fileRefs) =>
                 Promise.all(
-                    map(fileRefs, (ref) =>
+                    lodashMap(fileRefs, (ref) =>
                         fetch(ref.download_url).then((data) => data.json())
                     )
                 )
@@ -337,7 +337,11 @@ class Viewer extends React.Component<InputParams, ViewerState> {
 
     public convertFile(obj: Record<string, any>, fileType: TrajectoryType) {
         const fileName = uuidv4() + ".simularium";
-        this.setState({ convertingFile: true, conversionFileName: fileName });
+        this.setState({
+            conversionActive: true,
+            conversionFileName: fileName,
+        });
+
         simulariumController
             .convertTrajectory(
                 this.netConnectionSettings,
@@ -428,17 +432,23 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         });
     }
 
-    public receiveConvertedFile(data: TrajectoryFileInfo): void {
+    public receiveConvertedFile(): void {
         simulariumController
             .changeFile(
-                { netConnectionSettings: this.netConnectionSettings },
-                this.state.conversionFileName,
-                true
+                {
+                    netConnectionSettings: this.netConnectionSettings,
+                },
+                this.state.conversionFileName
             )
             .then(() => {
                 simulariumController.gotoTime(0);
             })
-            .then(() => this.setState({ convertingFile: false }))
+            .then(() =>
+                this.setState({
+                    conversionActive: false,
+                    conversionFileName: "",
+                })
+            )
             .catch((e) => {
                 console.warn(e);
             });
@@ -446,8 +456,8 @@ class Viewer extends React.Component<InputParams, ViewerState> {
 
     public handleTrajectoryInfo(data: TrajectoryFileInfo): void {
         console.log("Trajectory info arrived", data);
-        if (this.state.convertingFile === true) {
-            this.receiveConvertedFile(data);
+        if (this.state.conversionActive === true) {
+            this.receiveConvertedFile();
         }
         // NOTE: Currently incorrectly assumes initial time of 0
         const totalDuration = (data.totalSteps - 1) * data.timeStepSize;

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -87,7 +87,6 @@ interface ViewerState {
     initialPlay: boolean;
     firstFrameTime: number;
     followObjectData: AgentData;
-    conversionActive: boolean;
     conversionFileName: string;
 }
 
@@ -122,7 +121,6 @@ const initialState: ViewerState = {
     initialPlay: true,
     firstFrameTime: 0,
     followObjectData: nullAgent(),
-    conversionActive: false,
     conversionFileName: "",
 };
 
@@ -338,7 +336,6 @@ class Viewer extends React.Component<InputParams, ViewerState> {
     public convertFile(obj: Record<string, any>, fileType: TrajectoryType) {
         const fileName = uuidv4() + ".simularium";
         this.setState({
-            conversionActive: true,
             conversionFileName: fileName,
         });
 
@@ -445,7 +442,6 @@ class Viewer extends React.Component<InputParams, ViewerState> {
             })
             .then(() =>
                 this.setState({
-                    conversionActive: false,
                     conversionFileName: "",
                 })
             )
@@ -456,7 +452,8 @@ class Viewer extends React.Component<InputParams, ViewerState> {
 
     public handleTrajectoryInfo(data: TrajectoryFileInfo): void {
         console.log("Trajectory info arrived", data);
-        if (this.state.conversionActive === true) {
+        const conversionActive = !!this.state.conversionFileName;
+        if (conversionActive) {
             this.receiveConvertedFile();
         }
         // NOTE: Currently incorrectly assumes initial time of 0


### PR DESCRIPTION
Time Estimate or Size
=======
_small_

Problem
=======
During refactor of `ISimulator` I wanted to make sure I hadn't broken auto-conversion of a smoldyn file via the conversion form, but it doesn't seem to be working on main to begin with.


Solution
========
This is a simple mimic of how we do it in `simularium-website`. I'm not aiming to do any update or big refactor here just restore basic functionality so that we can have a before/after on future PRs that touch this code.

* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
Flag when a conversion is active in state, check that flag when receiving a file from the backend, and handle converted files appropriately.

Also restored the import of lodash `map` as it is used in the conversion process (may have been deleted in a clean up attempt that didn't test autoconversion flow), and added an alias for it, since it can be ambiguous when we are calling native vs lodash `map`.

Steps to Verify:
----------------
1. Go to conversion form, load a smoldyn file, and then see if it will convert and load
