### PR TITLE
Feature/brownian

### DIFF
--- a/examples/src/Components/FileSelect.tsx
+++ b/examples/src/Components/FileSelect.tsx
@@ -1,0 +1,103 @@
+import React, { useCallback, useEffect } from "react";
+import {
+    AWAITING_CONVERSION,
+    AWAITING_SMOLDYN_SIM_RUN,
+    TRAJECTORY_OPTIONS,
+} from "../constants";
+
+interface FileSelectionProps {
+    selectedFile: string;
+    onFileSelect: (file: string) => void;
+    loadSmoldynFile: () => void;
+    clearFile: () => void;
+    loadSmoldynPreConfiguredSim: () => void;
+    setRabbitCount: (count: string) => void;
+}
+
+const FileSelection = ({
+    selectedFile,
+    onFileSelect,
+    loadSmoldynFile,
+    clearFile,
+    loadSmoldynPreConfiguredSim,
+    setRabbitCount,
+}: FileSelectionProps): JSX.Element => {
+    useEffect(() => {
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has("file")) {
+            const queryStringFile = urlParams.get("file") || "";
+            onFileSelect(queryStringFile);
+        }
+    }, [onFileSelect]);
+
+    const handleFileSelect = useCallback(
+        (file: string) => {
+            if (
+                selectedFile === AWAITING_SMOLDYN_SIM_RUN ||
+                selectedFile === AWAITING_CONVERSION
+            ) {
+                return;
+            }
+            onFileSelect(file);
+        },
+        [selectedFile, onFileSelect]
+    );
+
+    const notInList =
+        selectedFile &&
+        selectedFile !== AWAITING_SMOLDYN_SIM_RUN &&
+        selectedFile !== AWAITING_CONVERSION &&
+        !TRAJECTORY_OPTIONS.some((t) => t.id === selectedFile);
+
+    return (
+        <div className={"ui-container"}>
+            <select
+                value={selectedFile}
+                onChange={(e) => handleFileSelect(e.target.value as string)}
+                style={{ maxWidth: 200 }}
+            >
+                <option value="" disabled>
+                    choose a file
+                </option>
+                {selectedFile === AWAITING_SMOLDYN_SIM_RUN && (
+                    <option value={AWAITING_SMOLDYN_SIM_RUN} disabled>
+                        Awaiting Smoldyn Sim Run...
+                    </option>
+                )}
+                {selectedFile === AWAITING_CONVERSION && (
+                    <option value={AWAITING_CONVERSION} disabled>
+                        Awaiting Autoconversion...
+                    </option>
+                )}
+                {Object.values(TRAJECTORY_OPTIONS).map((traj) => (
+                    <option key={traj.id} value={traj.id}>
+                        {traj.name}
+                    </option>
+                ))}
+                {notInList && (
+                    <option value={selectedFile}>{selectedFile}</option>
+                )}
+            </select>
+            <br></br>
+            <button onClick={() => clearFile()}>Clear trajectory </button>
+            <button onClick={loadSmoldynFile}>
+                Convert a smoldyn trajectory with
+            </button>
+            <button onClick={loadSmoldynPreConfiguredSim}>
+                Run pre-config Smoldyn sim via BioSimulators API
+            </button>
+            <br></br>
+            <label>
+                Initial Rabbit Count:
+                <input
+                    defaultValue="100"
+                    onChange={(event) => {
+                        setRabbitCount(event.target.value);
+                    }}
+                />
+            </label>
+        </div>
+    );
+};
+
+export default FileSelection;

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -19,6 +19,8 @@ import type {
     UIDisplayData,
     SelectionStateInfo,
     SelectionEntry,
+    AgentData,
+    IClientSimulatorImpl,
 } from "@aics/simularium-viewer";
 
 import PointSimulator from "./simulators/PointSimulator.ts";
@@ -34,8 +36,9 @@ import ColorPicker from "./Components/ColorPicker.tsx";
 import RecordMovieComponent from "./Components/RecordMovieComponent.tsx";
 import ConversionForm from "./Components/ConversionForm/index.tsx";
 import AgentMetadata from "./Components/AgentMetadata.tsx";
+import FileSelection from "./Components/FileSelect.tsx";
 
-import { agentColors } from "./constants.ts";
+import { agentColors, AWAITING_CONVERSION, AWAITING_SMOLDYN_SIM_RUN, TRAJECTORY_OPTIONS } from "./constants.ts";
 import { BaseType, CustomType } from "./types.ts";
 import {
     SMOLDYN_TEMPLATE,
@@ -47,14 +50,6 @@ import {
 
 import "@aics/simularium-viewer/style/style.css";
 import "./style.css";
-
-let playbackFile = "TEST_LIVEMODE_API";
-let queryStringFile = "";
-const urlParams = new URLSearchParams(window.location.search);
-if (urlParams.has("file")) {
-    queryStringFile = urlParams.get("file") || "";
-    playbackFile = queryStringFile;
-}
 
 interface ViewerState {
     renderStyle: RenderStyle;
@@ -75,16 +70,18 @@ interface ViewerState {
         template: { [key: string]: any };
         templateData: { [key: string]: any };
     } | null;
+    selectedFile: string;
     simulariumFile: {
         name: string;
         data: ISimulariumFile | null;
     } | null;
+    clientSimulator: boolean;
     serverHealthy: boolean;
     isRecordingEnabled: boolean;
     trajectoryTitle: string;
     initialPlay: boolean;
     firstFrameTime: number;
-    followObjectData: AgentData;
+    followObjectData: AgentData | null;
     conversionFileName: string;
 }
 
@@ -112,7 +109,9 @@ const initialState: ViewerState = {
         appliedColors: [],
     },
     filePending: null,
+    selectedFile: "TEST_LIVEMODE_API",
     simulariumFile: null,
+    clientSimulator: false,
     serverHealthy: false,
     isRecordingEnabled: true,
     trajectoryTitle: "",
@@ -181,11 +180,11 @@ class Viewer extends React.Component<InputParams, ViewerState> {
 
     public onError = (error: FrontEndError) => {
         if (error.level === ErrorLevel.ERROR) {
-            window.alert(
+            console.warn(
                 `ERROR, something is broken: ${error.message} ${error.htmlData}`
             );
         } else if (error.level === ErrorLevel.WARNING) {
-            window.alert(
+            console.warn(
                 `User warning, but not terrible:  ${error.message} ${error.htmlData}`
             );
         } else if (error.level === ErrorLevel.INFO) {
@@ -336,6 +335,7 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         const fileName = uuidv4() + ".simularium";
         this.setState({
             conversionFileName: fileName,
+            selectedFile: AWAITING_CONVERSION,
         });
 
         simulariumController
@@ -354,24 +354,34 @@ class Viewer extends React.Component<InputParams, ViewerState> {
     }
 
     public loadSmoldynSim() {
+        this.clearFile();
+        this.setState({ selectedFile: AWAITING_SMOLDYN_SIM_RUN });
         simulariumController.checkServerHealth(
             this.onHealthCheckResponse,
             this.netConnectionSettings
         );
-        const fileName = "smoldyn_sim" + uuidv4() + ".simularium"
+        const fileName = "smoldyn_sim" + uuidv4() + ".simularium";
         simulariumController
-            .startSmoldynSim(this.netConnectionSettings, fileName, this.smoldynInput)
+            .startSmoldynSim(
+                this.netConnectionSettings,
+                fileName,
+                this.smoldynInput
+            )
             .then(() => {
                 this.clearPendingFile();
             })
             .then(() => {
                 simulariumController.initNewFile(
-                    { netConnectionSettings: this.netConnectionSettings, },
-                    true,
-                )
+                    { netConnectionSettings: this.netConnectionSettings },
+                    true
+                );
+            })
+            .then(() => {
+                this.setState({ selectedFile: fileName });
             })
             .catch((err) => {
-                console.error(err);
+                console.error("Error starting Smoldyn sim: ", err);
+                this.setState({ selectedFile: "" });
             });
     }
 
@@ -452,16 +462,15 @@ class Viewer extends React.Component<InputParams, ViewerState> {
 
     public receiveConvertedFile(): void {
         simulariumController
-            .initNewFile(
-                {
-                    netConnectionSettings: this.netConnectionSettings,
-                },
-            )
+            .initNewFile({
+                netConnectionSettings: this.netConnectionSettings,
+            })
             .then(() => {
                 simulariumController.gotoTime(0);
             })
             .then(() =>
                 this.setState({
+                    selectedFile: this.state.conversionFileName,
                     conversionFileName: "",
                 })
             )
@@ -548,95 +557,136 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         });
     }
 
+    public clearFile() {
+        simulariumController.clearFile();
+        this.setState({
+            selectedFile: "",
+            simulariumFile: null,
+            clientSimulator: false,
+        });
+    }
+
+    private configureLocalClientSimulator(selectedFile: string) {
+        const config: { clientSimulator?: IClientSimulatorImpl } = {};
+
+        switch (selectedFile) {
+            case "TEST_LIVEMODE_API":
+                console.log("Using Live Mode API: PointSimulatorLive");
+                config.clientSimulator = new PointSimulatorLive(4, 4);
+                break;
+
+            case "TEST_POINTS":
+                config.clientSimulator = new PointSimulator(8000, 4);
+                break;
+
+            case "TEST_BINDING":
+                simulariumController.setCameraType(true);
+                config.clientSimulator = new BindingSimulator([
+                    { id: 0, count: 30, radius: 3, partners: [1, 2] },
+                    {
+                        id: 1,
+                        count: 300,
+                        radius: 1,
+                        partners: [0],
+                        kOn: 0.1,
+                        kOff: 0.5,
+                    },
+                    {
+                        id: 2,
+                        count: 300,
+                        radius: 1,
+                        partners: [0],
+                        kOn: 0.1,
+                        kOff: 0.5,
+                    },
+                ]);
+                break;
+
+            case "TEST_FIBERS":
+                config.clientSimulator = new CurveSimulator(1000, 4);
+                break;
+
+            case "TEST_SINGLE_FIBER":
+                config.clientSimulator = new SingleCurveSimulator();
+                break;
+
+            case "TEST_PDB":
+                config.clientSimulator = new PdbSimulator();
+                break;
+
+            case "TEST_SINGLE_PDB":
+                config.clientSimulator = new SinglePdbSimulator("3IRL");
+                break;
+
+            case "TEST_METABALLS":
+                config.clientSimulator = new MetaballSimulator();
+                break;
+            default:
+                break;
+        }
+        return config;
+    }
+
+    // in development, requires appropriate local branch of octopus
+    // to run Brownian Motion simulator
+    private configureRemoteClientSimulator(fileId: string) {
+        this.setState({
+            clientSimulator: true,
+            simulariumFile: { name: fileId, data: null },
+        });
+        simulariumController.changeFile(
+            {
+                netConnectionSettings: this.netConnectionSettings,
+                requestJson: true,
+            },
+            fileId
+        );
+    }
+
+    private handleFileSelect(file: string) {
+        simulariumController.stop();
+        this.clearFile();
+        this.setState({ selectedFile: file }, () => {
+            this.configureAndLoad();
+        });
+    }
+
     private configureAndLoad() {
         simulariumController.configureNetwork(this.netConnectionSettings);
-        if (playbackFile.startsWith("http")) {
-            return this.loadFromUrl(playbackFile);
+        if (
+            this.state.selectedFile === AWAITING_SMOLDYN_SIM_RUN ||
+            this.state.selectedFile === AWAITING_CONVERSION
+        ) {
+            return;
         }
-        if (playbackFile === "TEST_LIVEMODE_API") {
-            simulariumController.changeFile(
-                {
-                    clientSimulator: new PointSimulatorLive(4, 4),
-                },
-                playbackFile
-            );
-        } else if (playbackFile === "TEST_POINTS") {
-            simulariumController.changeFile(
-                {
-                    clientSimulator: new PointSimulator(8000, 4),
-                },
-                playbackFile
-            );
-        } else if (playbackFile === "TEST_BINDING") {
-            simulariumController.setCameraType(true);
-            simulariumController.changeFile(
-                {
-                    clientSimulator: new BindingSimulator([
-                        { id: 0, count: 30, radius: 3, partners: [1, 2] },
-                        {
-                            id: 1,
-                            count: 300,
-                            radius: 1,
-                            partners: [0],
-                            kOn: 0.1,
-                            kOff: 0.5,
-                        },
-                        {
-                            id: 2,
-                            count: 300,
-                            radius: 1,
-                            partners: [0],
-                            kOn: 0.1,
-                            kOff: 0.5,
-                        },
-                    ]),
-                },
-                playbackFile
-            );
-        } else if (playbackFile === "TEST_FIBERS") {
-            simulariumController.changeFile(
-                {
-                    clientSimulator: new CurveSimulator(1000, 4),
-                },
-                playbackFile
-            );
-        } else if (playbackFile === "TEST_SINGLE_FIBER") {
-            simulariumController.changeFile(
-                {
-                    clientSimulator: new SingleCurveSimulator(),
-                },
-                playbackFile
-            );
-        } else if (playbackFile === "TEST_PDB") {
-            simulariumController.changeFile(
-                {
-                    clientSimulator: new PdbSimulator(),
-                },
-                playbackFile
-            );
-        } else if (playbackFile === "TEST_SINGLE_PDB") {
-            simulariumController.changeFile(
-                {
-                    clientSimulator: new SinglePdbSimulator("3IRL"),
-                },
-                playbackFile
-            );
-        } else if (playbackFile === "TEST_METABALLS") {
-            simulariumController.changeFile(
-                {
-                    clientSimulator: new MetaballSimulator(),
-                },
-                playbackFile
-            );
-        } else {
+        if (this.state.selectedFile.startsWith("http")) {
+            return this.loadFromUrl(this.state.selectedFile);
+        }
+        const fileId = TRAJECTORY_OPTIONS.find(
+            (option) => option.id === this.state.selectedFile
+        );
+        if (!fileId) {
+            console.error("Invalid file id");
+            return;
+        }
+        if (fileId.clientSimulator) {
+            const clientSim = this.configureLocalClientSimulator(fileId.id);
+            simulariumController.changeFile(clientSim, fileId.id);
             this.setState({
-                simulariumFile: { name: playbackFile, data: null },
+                clientSimulator: true,
+            });
+            return;
+        } else if (fileId.remoteClientSimulator) {
+            this.configureRemoteClientSimulator(fileId.id);
+        } else if (fileId.networkedTrajectory) {
+            this.setState({
+                simulariumFile: { name: fileId.id, data: null },
             });
             simulariumController.changeFile(
                 {
                     netConnectionSettings: this.netConnectionSettings,
                 },
-                playbackFile
+                fileId.id
             );
         }
     }
@@ -711,6 +761,20 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         this.setState({ followObjectData: agentData });
     };
 
+    public updateBrownianSimulator = () => {
+        const updateData = {
+            data: {
+                agents: {
+                    "1": {
+                        _updater: "accumulate",
+                        position: [0.1, 0, 0],
+                    },
+                },
+            },
+        };
+        simulariumController.sendUpdate(updateData);
+    };
+
     public render(): JSX.Element {
         if (this.state.filePending) {
             const fileType = this.state.filePending.type;
@@ -725,65 +789,18 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         }
         return (
             <div className="container" style={{ height: "90%", width: "75%" }}>
-                <select
-                    onChange={(event) => {
-                        simulariumController.pause();
-                        playbackFile = event.target.value;
-                        this.configureAndLoad();
+                <FileSelection
+                    selectedFile={this.state.selectedFile}
+                    onFileSelect={(file: string) => {
+                        this.handleFileSelect(file);
                     }}
-                    defaultValue={playbackFile}
-                >
-                    <option value={queryStringFile}>{queryStringFile}</option>
-                    <option value="TEST_LIVEMODE_API">
-                        TEST LIVE MODE API
-                    </option>
-                    <option value="actin012_3.h5">Actin 12_3</option>
-                    <option value="listeria_rocketbugs_normal_fine_2_filtered.simularium">
-                        listeria 01
-                    </option>
-                    <option value="kinesin002_01.h5">kinesin 002</option>
-                    <option value="microtubules038_10.h5">MT 38</option>
-                    <option value="microtubules_v2_shrinking.h5">M Tub</option>
-                    <option value="aster.cmo">Aster</option>
-                    <option value="microtubules30_1.h5">MT 30</option>
-                    <option value="endocytosis.simularium">Endocytosis</option>
-                    <option value="pc4covid19.simularium">COVIDLUNG</option>
-                    <option value="nanoparticle_wrapping.simularium">
-                        Nanoparticle wrapping
-                    </option>
-                    <option value="smoldyn_min1.simularium">
-                        Smoldyn min1
-                    </option>
-                    <option value="smoldyn_spine.simularium">
-                        Smoldyn spine
-                    </option>
-                    <option value="medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.675.simularium">
-                        medyan 625
-                    </option>
-                    <option value="medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.0225.simularium">
-                        medyan 0225
-                    </option>
-                    <option value="springsalad_condensate_formation_Below_Ksp.simularium">
-                        springsalad below ksp
-                    </option>
-                    <option value="springsalad_condensate_formation_At_Ksp.simularium">
-                        springsalad at ksp
-                    </option>
-                    <option value="springsalad_condensate_formation_Above_Ksp.simularium">
-                        springsalad above ksp
-                    </option>
-                    <option value="blood-plasma-1.0.simularium">
-                        blood plasma
-                    </option>
-                    <option value="TEST_SINGLE_PDB">TEST SINGLE PDB</option>
-                    <option value="TEST_PDB">TEST PDB</option>
-                    <option value="TEST_SINGLE_FIBER">TEST SINGLE FIBER</option>
-                    <option value="TEST_FIBERS">TEST FIBERS</option>
-                    <option value="TEST_POINTS">TEST POINTS</option>
-                    <option value="TEST_METABALLS">TEST METABALLS</option>
-                    <option value="TEST_BINDING">TEST BINDING</option>
-                </select>
-
+                    loadSmoldynFile={() => this.loadSmoldynFile()}
+                    clearFile={this.clearFile.bind(this)}
+                    loadSmoldynPreConfiguredSim={() => this.loadSmoldynSim()}
+                    setRabbitCount={(count) => {
+                        this.smoldynInput = count;
+                    }}
+                />
                 <button onClick={() => this.translateAgent()}>
                     TranslateAgent
                 </button>
@@ -791,20 +808,18 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                     Clear
                 </button>
                 <button onClick={() => this.loadSmoldynFile()}>
-                    Load a smoldyn trajectory
+                    Convert a smoldyn trajectory
                 </button>
                 <br />
                 <label>
                     Initial Rabbit Count:
                     <input
                         defaultValue="100"
-                        onChange={(event) => {this.smoldynInput = event.target.value}}
+                        onChange={(event) => {
+                            this.smoldynInput = event.target.value;
+                        }}
                     />
                 </label>
-                <button onClick={() => this.loadSmoldynSim()}>
-                    Run Smoldyn
-                </button>
-                <br />
                 <button onClick={() => simulariumController.resume()}>
                     Play
                 </button>

--- a/examples/src/constants.ts
+++ b/examples/src/constants.ts
@@ -17,3 +17,124 @@ export const agentColors: string[] = [
     "#9f516c",
     "#00aabf",
 ];
+
+export const AWAITING_SMOLDYN_SIM_RUN = "awaiting_smoldyn_sim_run";
+export const AWAITING_CONVERSION = "awaiting_conversion";
+
+/**
+ * to do:
+ * work out type of sendUpdate messages per simulator
+ * client specific controls and other configuration
+ */
+
+export interface TrajectoryOptions {
+    id: string;
+    name: string;
+    clientSimulator?: boolean;
+    remoteClientSimulator?: boolean;
+    networkedTrajectory?: boolean;
+}
+
+export const TRAJECTORY_OPTIONS: TrajectoryOptions[] = [
+    {
+        id: "test_live_mode",
+        name: "test_live_mode",
+        remoteClientSimulator: true,
+        networkedTrajectory: true,
+    },
+    { id: "actin012_3.h5", name: "actin012_3.h5", networkedTrajectory: true },
+    {
+        id: "listeria_rocketbugs_normal_fine_2_filtered.simularium",
+        name: "listeria",
+        networkedTrajectory: true,
+    },
+    {
+        id: "kinesin002_01.h5",
+        name: "kinesin002_01.h5",
+        networkedTrajectory: true,
+    },
+    {
+        id: "microtubules038_10.h5",
+        name: "microtubules038_10.h5",
+        networkedTrajectory: true,
+    },
+    {
+        id: "microtubules_v2_shrinking.h5",
+        name: "microtubules_v2_shrinking.h5",
+        networkedTrajectory: true,
+    },
+    { id: "aster.cmo", name: "aster.cmo", networkedTrajectory: true },
+    {
+        id: "microtubules30_1.h5",
+        name: "microtubules",
+        networkedTrajectory: true,
+    },
+    {
+        id: "endocytosis.simularium",
+        name: "Actin in Clathrin-mediated Endocytosis",
+        networkedTrajectory: true,
+    },
+    {
+        id: "pc4covid19.simularium",
+        name: "SARS-CoV-2 Dynamics in Human Lung Epithelium",
+        networkedTrajectory: true,
+    },
+    {
+        id: "nanoparticle_wrapping.simularium",
+        name: "Membrane Wrapping a Nanoparticle",
+        networkedTrajectory: true,
+    },
+    {
+        id: "smoldyn_min1.simularium",
+        name: "Spatiotemporal oscillations in the E. coli Min system",
+        networkedTrajectory: true,
+    },
+    {
+        id: "smoldyn_spine.simularium",
+        name: "Sequestration of CaMKII in dendritic spines",
+        networkedTrajectory: true,
+    },
+    {
+        id: "medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.675.simularium",
+        name: "Actin Bundle Dynamics with α–Actinin and Myosin",
+        networkedTrajectory: true,
+    },
+    {
+        id: "medyan_Chandrasekaran_2019_UNI_alphaA_0.1_MA_0.0225.simularium",
+        name: "Actin Bundle Dynamics with α–Actinin and Myosin",
+        networkedTrajectory: true,
+    },
+    {
+        id: "springsalad_condensate_formation_Below_Ksp.simularium",
+        name: "Condensate Formation",
+        networkedTrajectory: true,
+    },
+    {
+        id: "springsalad_condensate_formation_At_Ksp.simularium",
+        name: "Condensate Formation",
+        networkedTrajectory: true,
+    },
+    {
+        id: "springsalad_condensate_formation_Above_Ksp.simularium",
+        name: "Condensate Formation",
+        networkedTrajectory: true,
+    },
+    {
+        id: "blood-plasma-1.0.simularium",
+        name: "Blood Plasma",
+        networkedTrajectory: true,
+    },
+    { id: "TEST_POINTS", name: "Point Simulation", clientSimulator: true },
+    {
+        id: "TEST_LIVEMODE_API",
+        name: "Point Simulation LIVE",
+        clientSimulator: true,
+    },
+    { id: "TEST_BINDING", name: "Binding Simulation", clientSimulator: true },
+    { id: "TEST_FIBERS", name: "Fiber Simulation", clientSimulator: true },
+    { id: "TEST_SINGLE_FIBER", name: "Single Fiber", clientSimulator: true },
+    { id: "TEST_PDB", name: "PDB Simulation", clientSimulator: true },
+    { id: "TEST_SINGLE_PDB", name: "Single PDB", clientSimulator: true },
+    { id: "TEST_METABALLS", name: "Metaballs", clientSimulator: true },
+    { id: "TEST_VALUE_SPHERES", name: "Value Spheres", clientSimulator: true },
+];

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -42,6 +42,7 @@ interface SimulatorConnectionParams {
     clientSimulator?: IClientSimulatorImpl;
     simulariumFile?: ISimulariumFile;
     geoAssets?: { [key: string]: string };
+    requestJson?: boolean;
 }
 
 export default class SimulariumController {
@@ -127,7 +128,8 @@ export default class SimulariumController {
         netConnectionConfig?: NetConnectionParams,
         clientSimulator?: IClientSimulatorImpl,
         localFile?: ISimulariumFile,
-        geoAssets?: { [key: string]: string }
+        geoAssets?: { [key: string]: string },
+        requestJson?: boolean
     ): void {
         if (clientSimulator) {
             this.simulator = new ClientSimulator(clientSimulator);
@@ -152,7 +154,11 @@ export default class SimulariumController {
             );
             this.remoteWebsocketClient = webSocketClient;
             this.octopusClient = new OctopusServicesClient(webSocketClient);
-            this.simulator = new RemoteSimulator(webSocketClient, this.onError);
+            this.simulator = new RemoteSimulator(
+                webSocketClient,
+                this.onError,
+                requestJson
+            );
             this.simulator.setTrajectoryDataHandler(
                 this.visData.parseAgentsFromNetData.bind(this.visData)
             );
@@ -384,7 +390,8 @@ export default class SimulariumController {
                         connectionParams.netConnectionSettings,
                         connectionParams.clientSimulator,
                         connectionParams.simulariumFile,
-                        connectionParams.geoAssets
+                        connectionParams.geoAssets,
+                        connectionParams.requestJson
                     );
                     this.isPaused = true;
                 } else {


### PR DESCRIPTION
Time Estimate or Size
=======
_medium_

A lot of these changes are just moving existing functionality or data into components/constants. I will try to highlight actual changes in comments!

Problem
=======
Advances #428
Advances #450

Setting up interaction with the Brownian Motion simulator hosted on Octopus.
(currently requires running a dev branch of octopus `test/fix-json-brownian-simulator`)

Solution
========
Pulled functionality for file selection into component, some refinement of file loading and configuration methods.
Loading client sims, networked trajectories, auto-conversion, and Biosimulators API run should all still work as before.

### `FileSelect`
Ongoing effort to pull big chunks of JSX into components to make the test-bed easier to read. Agent selection functionality is unchanged, just nested down. File selection uses `selectedFile` in state over previous `playbackFile`.

### Controller and RemoteSimulator
Take an optional flag for `requestJson` in `SimulatorConnectionParams` to send the right requests to Octopus when using the brownian motion simulator