### PR TITLE
bug fixes

### DIFF
--- a/examples/src/Components/ColorPicker.tsx
+++ b/examples/src/Components/ColorPicker.tsx
@@ -30,7 +30,7 @@ const ColorPicker = ({
         if (!agent) {
             throw new Error("No agent found");
         }
-        if (!agent.displayStates.length) {
+        if (agent.displayStates.length === 0) {
             setSubAgents([{ name: "<unmodified>", id: "<unmodified>" }]);
             return;
         }

--- a/examples/src/Components/ColorPicker.tsx
+++ b/examples/src/Components/ColorPicker.tsx
@@ -30,6 +30,10 @@ const ColorPicker = ({
         if (!agent) {
             throw new Error("No agent found");
         }
+        if (!agent.displayStates.length) {
+            setSubAgents([{ name: "<unmodified>", id: "<unmodified>" }]);
+            return;
+        }
         setSubAgents(agent.displayStates);
     };
 

--- a/src/simularium/VisDataParse.ts
+++ b/src/simularium/VisDataParse.ts
@@ -57,7 +57,7 @@ function parseVisDataMessage(visDataMsg: VisDataMessage): CachedFrame {
         writeIndex += FRAME_DATA_SIZE;
 
         // Validate data integrity
-        if (--readIndex + nSubPoints > frame.data.length) {
+        if (readIndex + nSubPoints > frame.data.length) {
             throw new FrontEndError(
                 `Your data is malformed, there are too few entries. Found ${
                     frame.data.length


### PR DESCRIPTION
Time Estimate or Size
=======
_tiny_

Problem / Solution
=======
fixes two bugs
- test bed color picker wasn't working for agents without display states
- decrementing read index in `VisDataParse` was grabbing data off by one index when parsing fiber agent sub points
