### PR TITLE
add cache logging callback

### DIFF
--- a/examples/src/Components/CacheLogDisplay.tsx
+++ b/examples/src/Components/CacheLogDisplay.tsx
@@ -16,19 +16,17 @@ const CacheLogDisplay: React.FC<CacheLogDisplayProps> = ({
 
     return (
         <div className="ui-container">
-            <>
-                <div>Cache Enabled: {cacheEnabled ? "Yes" : "No"}</div>
-                <div>Current cache size: {size}</div>
-                <div> Max Size: {maxSize}</div>
-                <div>First Frame Number: {framesInCache[0]}</div>
-                <div>
-                    Last Frame Number: {framesInCache[framesInCache.length - 1]}
-                </div>
-                <div>
-                    {framesInCache.length} frames in Cache:{" "}
-                    {framesInCache.join(", ")}
-                </div>
-            </>
+            <div>Cache Enabled: {cacheEnabled ? "Yes" : "No"}</div>
+            <div>Current cache size: {size}</div>
+            <div> Max Size: {maxSize}</div>
+            <div>First Frame Number: {framesInCache[0]}</div>
+            <div>
+                Last Frame Number: {framesInCache[framesInCache.length - 1]}
+            </div>
+            <div>
+                {framesInCache.length} frames in Cache:{" "}
+                {framesInCache.join(", ")}
+            </div>
         </div>
     );
 };

--- a/examples/src/Components/CacheLogDisplay.tsx
+++ b/examples/src/Components/CacheLogDisplay.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { CacheLog } from "../../../type-declarations/simularium";
+
+interface CacheLogDisplayProps {
+    cacheLog: CacheLog;
+    cacheEnabled: boolean;
+    maxSize: number;
+}
+
+const CacheLogDisplay: React.FC<CacheLogDisplayProps> = ({
+    cacheLog,
+    cacheEnabled,
+    maxSize,
+}) => {
+    const { size, framesInCache } = cacheLog;
+
+    return (
+        <div className="ui-container">
+            <>
+                <div>Cache Enabled: {cacheEnabled ? "Yes" : "No"}</div>
+                <div>Current cache size: {size}</div>
+                <div> Max Size: {maxSize}</div>
+                <div>First Frame Number: {framesInCache[0]}</div>
+                <div>
+                    Last Frame Number: {framesInCache[framesInCache.length - 1]}
+                </div>
+                <div>
+                    {framesInCache.length} frames in Cache:{" "}
+                    {framesInCache.join(", ")}
+                </div>
+            </>
+        </div>
+    );
+};
+
+export default CacheLogDisplay;

--- a/examples/src/Viewer.tsx
+++ b/examples/src/Viewer.tsx
@@ -21,6 +21,7 @@ import type {
     SelectionEntry,
     AgentData,
     IClientSimulatorImpl,
+    CacheLog,
 } from "@aics/simularium-viewer";
 
 import PointSimulator from "./simulators/PointSimulator.ts";
@@ -38,6 +39,7 @@ import ConversionForm from "./Components/ConversionForm/index.tsx";
 import AgentMetadata from "./Components/AgentMetadata.tsx";
 import FileSelection from "./Components/FileSelect.tsx";
 import AgentSelectionControls from "./Components/AgentSelection.tsx";
+import CacheLogDisplay from "./Components/CacheLogDisplay.tsx";
 
 import {
     agentColors,
@@ -89,6 +91,8 @@ interface ViewerState {
     firstFrameTime: number;
     followObjectData: AgentData | null;
     conversionFileName: string;
+    cacheLog: CacheLog;
+    cacheDisabled: boolean;
 }
 
 const simulariumController = new SimulariumController({});
@@ -125,6 +129,11 @@ const initialState: ViewerState = {
     firstFrameTime: 0,
     followObjectData: null,
     conversionFileName: "",
+    cacheLog: {
+        size: 0,
+        framesInCache: [],
+    },
+    cacheDisabled: false,
 };
 
 class Viewer extends React.Component<InputParams, ViewerState> {
@@ -791,6 +800,12 @@ class Viewer extends React.Component<InputParams, ViewerState> {
         simulariumController.sendUpdate(updateData);
     };
 
+    public handleCacheUpdate = (log: CacheLog) => {
+        this.setState({
+            cacheLog: log,
+        });
+    };
+
     public render(): JSX.Element {
         if (this.state.filePending) {
             const fileType = this.state.filePending.type;
@@ -1068,7 +1083,11 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                             </div>
                         </div>
                         <div className="logs">
-                            {/* todo add cache logs here */}
+                            <CacheLogDisplay
+                                cacheLog={this.state.cacheLog}
+                                cacheEnabled={simulariumController.visData.isCacheEnabled()}
+                                maxSize={simulariumController.visData.getMaxCacheSize()}
+                            />
                         </div>
                     </div>
                     <div className="viewer-container">
@@ -1108,6 +1127,9 @@ class Viewer extends React.Component<InputParams, ViewerState> {
                                 lockedCamera={false}
                                 disableCache={false}
                                 maxCacheSize={Infinity} //  means no limit, provide limits in bytes, 1MB = 1000000, 1GB = 1000000000
+                                onCacheUpdate={this.handleCacheUpdate.bind(
+                                    this
+                                )}
                             />
                         </div>
                     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type {
     VisDataMessage,
     Plot,
     AgentData,
+    CacheLog,
 } from "./simularium/index.js";
 export type { ISimulariumFile } from "./simularium/ISimulariumFile.js";
 export type { TimeData } from "./viewport/index.js";

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -50,6 +50,14 @@ class VisData {
         this.onError = onError;
     }
 
+    public isCacheEnabled(): boolean {
+        return this.frameCache.cacheEnabled;
+    }
+
+    public getMaxCacheSize(): number {
+        return this.frameCache.maxSize;
+    }
+
     public get currentFrameData(): CachedFrame {
         if (!this.frameCache.hasFrames()) {
             return nullCachedFrame();

--- a/src/simularium/VisDataCache.ts
+++ b/src/simularium/VisDataCache.ts
@@ -138,10 +138,7 @@ class VisDataCache {
     }
 
     public getFirstFrameNumber(): number {
-        if (this.head !== null) {
-            return this.head.data.frameNumber;
-        }
-        return -1;
+        return this.head?.data.frameNumber ?? -1;
     }
 
     public getFirstFrameTime(): number {
@@ -153,10 +150,7 @@ class VisDataCache {
     }
 
     public getLastFrameNumber(): number {
-        if (this.tail !== null) {
-            return this.tail.data.frameNumber;
-        }
-        return -1;
+        return this.tail?.data.frameNumber ?? -1;
     }
 
     public getLastFrameTime(): number {

--- a/src/simularium/VisDataCache.ts
+++ b/src/simularium/VisDataCache.ts
@@ -57,11 +57,11 @@ class VisDataCache {
     public onCacheUpdate(): void {
         this.logCacheUpdate?.({
             size: this.size,
-            framesInCache: this.getListOfCachedFrameNumbers(),
+            framesInCache: this.getCachedFrameNumbers(),
         });
     }
 
-    private getListOfCachedFrameNumbers(): number[] {
+    private getCachedFrameNumbers(): number[] {
         const frameNumbers: number[] = [];
         let current: CacheNode | null = this.head;
         while (current !== null) {

--- a/src/simularium/index.ts
+++ b/src/simularium/index.ts
@@ -9,6 +9,7 @@ export type {
     SimulariumFileFormat,
     Plot,
     AgentData,
+    CacheLog,
 } from "./types.js";
 
 export type {

--- a/src/simularium/types.ts
+++ b/src/simularium/types.ts
@@ -209,3 +209,8 @@ export interface CacheNode {
     next: CacheNode | null;
     prev: CacheNode | null;
 }
+
+export interface CacheLog {
+    size: number;
+    framesInCache: number[];
+}

--- a/src/test/VisData.test.ts
+++ b/src/test/VisData.test.ts
@@ -15,39 +15,73 @@ import { nullCachedFrame } from "../util.js";
 //  moving linearly from (0,0,0) to (5,5,5)
 //  and rotating 0-90 degrees around the x axis
 //  over 5 frames from time 0-20
-const testData = {
-    fileName: "",
-    msgType: 1,
-    bundleSize: 5,
-    bundleStart: 0,
-    bundleData: [
-        {
-            frameNumber: 0,
-            time: 0,
-            data: [1000, 0, 7, 1, 1, 1, 0, 0, 0, 1, 0],
-        },
-        {
-            frameNumber: 1,
-            time: 5,
-            data: [1000, 0, 7, 2, 2, 2, 0, 22.5, 0, 1, 0],
-        },
-        {
-            frameNumber: 2,
-            time: 10,
-            data: [1000, 0, 7, 3, 3, 3, 0, 45, 0, 1, 0],
-        },
-        {
-            frameNumber: 3,
-            time: 15,
-            data: [1000, 0, 7, 4, 4, 4, 0, 67.5, 0, 1, 0],
-        },
-        {
-            frameNumber: 4,
-            time: 20,
-            data: [1000, 0, 7, 5, 5, 5, 0, 90, 0, 1, 0],
-        },
-    ],
-};
+const testData = [
+    {
+        fileName: "",
+        msgType: 1,
+        bundleSize: 1,
+        bundleStart: 0,
+        bundleData: [
+            {
+                frameNumber: 0,
+                time: 0,
+                data: [1000, 0, 7, 1, 1, 1, 0, 0, 0, 1, 0],
+            },
+        ],
+    },
+    {
+        fileName: "",
+        msgType: 1,
+        bundleSize: 1,
+        bundleStart: 1,
+        bundleData: [
+            {
+                frameNumber: 1,
+                time: 5,
+                data: [1000, 0, 7, 2, 2, 2, 0, 22.5, 0, 1, 0],
+            },
+        ],
+    },
+    {
+        fileName: "",
+        msgType: 1,
+        bundleSize: 1,
+        bundleStart: 2,
+        bundleData: [
+            {
+                frameNumber: 2,
+                time: 10,
+                data: [1000, 0, 7, 3, 3, 3, 0, 45, 0, 1, 0],
+            },
+        ],
+    },
+    {
+        fileName: "",
+        msgType: 1,
+        bundleSize: 1,
+        bundleStart: 3,
+        bundleData: [
+            {
+                frameNumber: 3,
+                time: 15,
+                data: [1000, 0, 7, 4, 4, 4, 0, 67.5, 0, 1, 0],
+            },
+        ],
+    },
+    {
+        fileName: "",
+        msgType: 1,
+        bundleSize: 1,
+        bundleStart: 4,
+        bundleData: [
+            {
+                frameNumber: 4,
+                time: 20,
+                data: [1000, 0, 7, 5, 5, 5, 0, 90, 0, 1, 0],
+            },
+        ],
+    },
+];
 
 describe("VisData module", () => {
     describe("VisData parse", () => {
@@ -203,7 +237,9 @@ describe("VisData module", () => {
         });
         test("can find frames in cache by time", () => {
             const visData = new VisData();
-            visData.parseAgentsFromNetData(testData);
+            testData.forEach((frame) => {
+                visData.parseAgentsFromNetData(frame);
+            });
 
             const i = 0;
             while (!visData.atLatestFrame()) {

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -12,7 +12,7 @@ import {
     SelectionStateInfo,
     UIDisplayData,
 } from "../simularium/index.js";
-import { AgentData, TrajectoryFileInfoAny } from "../simularium/types.js";
+import { AgentData, CacheLog, TrajectoryFileInfoAny } from "../simularium/types.js";
 import { updateTrajectoryFileInfoFormat } from "../simularium/versionHandlers.js";
 import { FrontEndError, ErrorLevel } from "../simularium/FrontEndError.js";
 import { RenderStyle, VisGeometry, NO_AGENT } from "../visGeometry/index.js";
@@ -36,6 +36,7 @@ type ViewportProps = {
         cachedData: TrajectoryFileInfo
     ) => void | undefined;
     onUIDisplayDataChanged: (data: UIDisplayData) => void | undefined;
+    onCacheUpdate?: (log: CacheLog) => void;
     loadInitialData: boolean;
     hideAllAgents: boolean;
     showPaths: boolean;
@@ -130,6 +131,7 @@ class Viewport extends React.Component<
         this.props.simulariumController.visData.frameCache.changeSettings({
             cacheEnabled: !props.disableCache,
             maxSize: props.maxCacheSize,
+            onCacheUpdate: props.onCacheUpdate,
         });
         if (props.onError) {
             this.props.simulariumController.visData.setOnError(props.onError);


### PR DESCRIPTION
Time Estimate or Size
=======
_small_

Problem
=======
Advances #423 

Solution
========
The logging component from the previous prefetching branch, pulled out to keep work encapsulated. This didn't have any issues previously besides feedback that it logged too much data, I've pared down the log to just current cache size and array of the frame numbers in the cache. Added getters for maxSize and cacheEnabled as those don't change rapidly and don't need to be in the log.

Also unbundled the test data in `VisData.test.ts` to match how our data is sent now.

* New feature (non-breaking change which adds functionality)

<img width="300" alt="Screenshot 2025-03-18 at 4 44 30 PM" src="https://github.com/user-attachments/assets/f5841b8a-09ae-41ab-b670-63eb2fc71247" />

