### PR TITLE
Bug Fix: Blood Plasma Simularium Example

### DIFF
--- a/src/visGeometry/GeometryStore.ts
+++ b/src/visGeometry/GeometryStore.ts
@@ -221,7 +221,7 @@ class GeometryStore {
             // TODO:
             // Can we confirm that the rcsb.org servers have every id as a cif file?
             // If so, then we don't need to do this second try and we can always use .cif.
-            actualUrl = `https://files.rcsb.org/download/${pdbID}-assembly1.cif`;
+            actualUrl = `https://files.rcsb.org/download${pdbID}-assembly1.cif`;
         }
         return fetch(actualUrl)
             .then((response) => {
@@ -229,7 +229,7 @@ class GeometryStore {
                     return response.text();
                 } else if (pdbID) {
                     // try again as pdb
-                    actualUrl = `https://files.rcsb.org/download/${pdbID}.pdb1`;
+                    actualUrl = `https://files.rcsb.org/download${pdbID}.pdb1`;
                     return fetch(actualUrl).then((response) => {
                         if (!response.ok) {
                             // error will be caught by the function that calls this

--- a/src/visGeometry/GeometryStore.ts
+++ b/src/visGeometry/GeometryStore.ts
@@ -74,6 +74,18 @@ class GeometryStore {
         return true;
     };
 
+    private static getPdbUrlFromSanitizedPdbId = (
+        pdbId: string,
+        isCif: boolean
+    ) => {
+        // Note: pdbId will have a leading backslash, which was prepended
+        // in checkAndSanitizePath
+        if (isCif) {
+            return `https://files.rcsb.org/download${pdbId}-assembly1.cif`;
+        }
+        return `https://files.rcsb.org/download${pdbId}.pdb1`;
+    };
+
     constructor(loggerLevel?: ILogLevel) {
         this._geoLoadAttempted = new Map<string, boolean>();
         this._cachedAssets = new Map<string, string>();
@@ -221,7 +233,7 @@ class GeometryStore {
             // TODO:
             // Can we confirm that the rcsb.org servers have every id as a cif file?
             // If so, then we don't need to do this second try and we can always use .cif.
-            actualUrl = `https://files.rcsb.org/download${pdbID}-assembly1.cif`;
+            actualUrl = GeometryStore.getPdbUrlFromSanitizedPdbId(pdbID, true);
         }
         return fetch(actualUrl)
             .then((response) => {
@@ -229,7 +241,10 @@ class GeometryStore {
                     return response.text();
                 } else if (pdbID) {
                     // try again as pdb
-                    actualUrl = `https://files.rcsb.org/download${pdbID}.pdb1`;
+                    actualUrl = GeometryStore.getPdbUrlFromSanitizedPdbId(
+                        pdbID,
+                        false
+                    );
                     return fetch(actualUrl).then((response) => {
                         if (!response.ok) {
                             // error will be caught by the function that calls this


### PR DESCRIPTION
Time Estimate or Size
=======
tiny

Problem
=======
I noticed that the [Blood Plasma visualization on the simularium website](https://simularium.allencell.org/viewer?trajFileName=blood-plasma-1.0.simularium) isn't fully working in both staging and production, because the website is failing to fetch a number of the PDB files. 

If you look at the error messages, you can see that all of the URLs that were couldn't be fetched had two backslashes in a row before the PDB file name. If you remove one of the backslashes, the URL will be valid.

Solution
========
Before it is passed to `fetchPDB()` from `GeometryStore.attemptToLoadGeometry()`, the PDB path goes through `checkAndSanitizePath` (see [here](https://github.com/simularium/simularium-viewer/blob/f42e53cade3dab5583f56dfa0e6989e76019a22d/src/util.ts#L39)) in `GeometryStore.mapKeyToGeom()`, which prepends a backslash. 

I imagine it's a good idea to check / sanitize the path, so I don't want to remove that, and I don't want to change checkAndSanitizePath because it is used elsewhere. Since this is the only path that gets to `fetchPDB()`, I decided the easiest thing to do would be to just change the hardcoded URLs we're putting the PDB path into to not have the other backslash? I've never touched any of these files, so I'm just trying to minimize the chances of accidentally breaking stuff.

Also I have no idea how long this has been broken, none of these files have been touched very recently.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

<img width="1443" alt="Screen Shot 2025-05-02 at 3 03 22 PM" src="https://github.com/user-attachments/assets/a5b680c1-e802-4760-bc79-50e374013367" />
