### PR TITLE
add export field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
         "registry": "https://registry.npmjs.org/",
         "access": "public"
     },
+    "exports": {
+        ".": "./es/index.js",
+        "./style/style.css": "./style/style.css"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/simularium/simularium-viewer.git"


### PR DESCRIPTION
Time Estimate or Size
=======
_small_

Problem
=======
Installing current viewer version is breaking the website build

It seems the way we are exporting our stylesheet from the viewer, the website bundler can't grab it correctly.
https://webpack.js.org/guides/package-exports/

I was able to inspect `/es` in the node_modules of the website and see the file we were trying to import, but the bundled website was not including it without the explicit export in package.json of the viewer.

Solution
========
Adding "exports" field to package.json tells webpack to bundle the stylesheet during website build.

Locally I can test the fix both a dev build via a directory and a `.tgz`, but I get a little dizzy making changes to both repos, rebuilding, repacking, and reinstalling so I would appreciate a double check, we can also try by just patching the published version.

The unfortunate thing, which I also don't understand, is that this seemed to trigger some breakages in the typing on our styled components in the website.

I have no idea why, it does make sense because we had a mismatch in our v6 `styled-components` and `@types/styled-components` version, but I don't know why the viewer build seemed to trigger it.

Either way, I have a draft PR here for the website that fixes the typing on the styled components.
When we publish the viewer patch, I will install it on that branch, and then hopefully we will see a successful website build.

* Bug fix (non-breaking change which fixes an issue)

Final confirmation will be a successful website build with the ability to alt-ctrl-1 to see the advanced controls.
