### PR TITLE
need to include types in export

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,13 @@
         "url": "https://github.com/simularium/simularium-viewer.git"
     },
     "exports": {
-        ".": "./es/index.js",
-        "./style/style.css": "./es/style/style.css"
+        "./style/style.css": "./es/style/style.css",
+        ".": {
+            "import": {
+                "types": "./type-declarations/index.d.ts",
+                "default": "./es/index.js"
+            }
+        }
     },
     "author": "",
     "license": "MIT",


### PR DESCRIPTION
Time Estimate or Size
=======
xsmall

Problem
=======
when installing the app with vite, i got a typescript error 

```
Could not find a declaration file for module '@aics/simularium-viewer'. '/Users/meganr/dev/simularium-org/simularium-viewer/es/index.js' implicitly has an 'any' type.
  There are types at '/Users/meganr/dev/simularium-org/binding-sim-edu/node_modules/@aics/simularium-viewer/type-declarations/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@aics/simularium-viewer' library may need to update its package.json or typings.ts(7016)
```

Solution
========
followed this documentation for exporting types https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

