### PR TITLE
read frameNumber from intView when parsing binary frame

### DIFF
--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -24,7 +24,7 @@ class VisData {
         const intView = new Uint32Array(data);
         const frameData: CachedFrame = {
             data: data,
-            frameNumber: floatView[0],
+            frameNumber: intView[0],
             time: floatView[1],
             agentCount: intView[2],
             size: 0,


### PR DESCRIPTION
Time Estimate or Size
=======
xsmall

Problem
=======
Binary files are failing to run when we press "play", but are working to just step through each frame
[Part of this ticket](https://github.com/simularium/simulariumio/issues/200)

Solution
========
When decoding the binary frame data, read the frameNumber as an int instead of a float