### PR TITLE
publish-dev workflow write permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
         if: github.ref == 'refs/heads/main'
         needs: [lint, typeCheck, test]
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #4.3.1
             - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 #v6.2.0


### PR DESCRIPTION
Time Estimate or Size
=======
xsmall

Problem
=======
Noticed that CI was broken after merging a dependabot PR, the publish-dev workflow needs write permissions to be able to push to a branch.


* Bug fix (non-breaking change which fixes an issue)